### PR TITLE
add typescript support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,11 @@ module.exports = {
 				'**/*.spec.js',
 			],
 			extends: [ 'plugin:@wordpress/eslint-plugin/test-unit' ],
+			settings: {
+				jest: {
+					version: 26,
+				},
+			},
 		},
 	],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,4 +16,17 @@ module.exports = {
 			},
 		],
 	},
+	overrides: [
+		{
+			files: [
+				'**/test/**/*.ts',
+				'**/test/**/*.js',
+				'**/__tests__/**/*.ts',
+				'**/__tests__/**/*.js',
+				'**/*.spec.ts',
+				'**/*.spec.js',
+			],
+			extends: [ 'plugin:@wordpress/eslint-plugin/test-unit' ],
+		},
+	],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2227,6 +2227,18 @@
 				"stylis": "^4.0.3"
 			}
 		},
+		"@emotion/css": {
+			"version": "11.1.3",
+			"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.1.3.tgz",
+			"integrity": "sha512-RSQP59qtCNTf5NWD6xM08xsQdCZmVYnX/panPYvB6LQAPKQB6GL49Njf0EMbS3CyDtrlWsBcmqBtysFvfWT3rA==",
+			"requires": {
+				"@emotion/babel-plugin": "^11.0.0",
+				"@emotion/cache": "^11.1.3",
+				"@emotion/serialize": "^1.0.0",
+				"@emotion/sheet": "^1.0.0",
+				"@emotion/utils": "^1.0.0"
+			}
+		},
 		"@emotion/hash": {
 			"version": "0.8.0",
 			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
@@ -2777,6 +2789,11 @@
 			"integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
 			"dev": true
 		},
+		"@popperjs/core": {
+			"version": "2.10.2",
+			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
+			"integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ=="
+		},
 		"@sideway/address": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
@@ -2980,6 +2997,33 @@
 			"requires": {
 				"defer-to-connect": "^2.0.0"
 			}
+		},
+		"@tannin/compile": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
+			"integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
+			"requires": {
+				"@tannin/evaluate": "^1.2.0",
+				"@tannin/postfix": "^1.1.0"
+			}
+		},
+		"@tannin/evaluate": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
+			"integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg=="
+		},
+		"@tannin/plural-forms": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
+			"integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
+			"requires": {
+				"@tannin/compile": "^1.1.0"
+			}
+		},
+		"@tannin/postfix": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
+			"integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw=="
 		},
 		"@tootallnate/once": {
 			"version": "1.1.2",
@@ -3239,6 +3283,11 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/lodash": {
+			"version": "4.14.149",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+			"integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
+		},
 		"@types/mdast": {
 			"version": "3.0.10",
 			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz",
@@ -3259,6 +3308,11 @@
 			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
 			"dev": true
+		},
+		"@types/mousetrap": {
+			"version": "1.6.8",
+			"resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.8.tgz",
+			"integrity": "sha512-zTqjvgCUT5EoXqbqmd8iJMb4NJqyV/V7pK7AIKq7qcaAsJIpGlTVJS1HQM6YkdHCdnkNSbhcQI7MXYxFfE3iCA=="
 		},
 		"@types/node": {
 			"version": "16.6.1",
@@ -3344,6 +3398,12 @@
 			"integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
 			"dev": true
 		},
+		"@types/tinycolor2": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.3.tgz",
+			"integrity": "sha512-Kf1w9NE5HEgGxCRyIcRXR/ZYtDv0V8FVPtYHwLxl0O+maGX0erE77pQlD0gpP+/KByMZ87mOA79SjifhSB3PjQ==",
+			"dev": true
+		},
 		"@types/uglify-js": {
 			"version": "3.13.1",
 			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.13.1.tgz",
@@ -3426,6 +3486,137 @@
 					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
 					"dev": true
 				}
+			}
+		},
+		"@types/wordpress__block-editor": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__block-editor/-/wordpress__block-editor-6.0.4.tgz",
+			"integrity": "sha512-8l9E+R/y4yrAopjuJieHvzBD/SRtKE5IwC4unC/4WWYQCbt2WeXNK+bYRBrtHtKi1PKnVAcqPXkpOGWyxfUOzA==",
+			"dev": true,
+			"requires": {
+				"@types/react": "*",
+				"@types/wordpress__blocks": "*",
+				"@types/wordpress__components": "*",
+				"@types/wordpress__data": "*",
+				"@types/wordpress__keycodes": "*",
+				"@wordpress/element": "^3.0.0",
+				"react-autosize-textarea": "^7.1.0"
+			},
+			"dependencies": {
+				"@wordpress/element": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.2.0.tgz",
+					"integrity": "sha512-YXJhtBF8FnFYwA9X6Dvs4k6yJf5wy1lhU04VNJVzoUDwCt/pK747RGePIPDdUWVd3X/TlyNH2yLRtcCyOC/SzQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^2.2.0",
+						"lodash": "^4.17.21",
+						"react": "^17.0.1",
+						"react-dom": "^17.0.1"
+					}
+				}
+			}
+		},
+		"@types/wordpress__blocks": {
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__blocks/-/wordpress__blocks-9.1.1.tgz",
+			"integrity": "sha512-E4tMCascyIeTeBn3olJXRDESXQWsRsCVSnuaeIrznIR5wjJbUDSQBZF/GeFLjfIraHLGV2I5++r11GcPcXp0Ig==",
+			"dev": true,
+			"requires": {
+				"@types/react": "*",
+				"@types/wordpress__components": "*",
+				"@types/wordpress__data": "*",
+				"@wordpress/element": "^3.0.0"
+			},
+			"dependencies": {
+				"@wordpress/element": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.2.0.tgz",
+					"integrity": "sha512-YXJhtBF8FnFYwA9X6Dvs4k6yJf5wy1lhU04VNJVzoUDwCt/pK747RGePIPDdUWVd3X/TlyNH2yLRtcCyOC/SzQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^2.2.0",
+						"lodash": "^4.17.21",
+						"react": "^17.0.1",
+						"react-dom": "^17.0.1"
+					}
+				}
+			}
+		},
+		"@types/wordpress__components": {
+			"version": "14.0.4",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__components/-/wordpress__components-14.0.4.tgz",
+			"integrity": "sha512-fAscxuuplXCAbqThc+YDMuhixlT/beUbcQalBEfrmnE2rcvaDJu6rDXlZjZyMF9qJeS+UOaFdbpWf2fAG/skzQ==",
+			"dev": true,
+			"requires": {
+				"@types/react": "*",
+				"@types/tinycolor2": "*",
+				"@types/wordpress__components": "*",
+				"@types/wordpress__notices": "*",
+				"@types/wordpress__rich-text": "*",
+				"@wordpress/element": "^3.0.0",
+				"downshift": "^6.0.15",
+				"re-resizable": "^6.4.0"
+			},
+			"dependencies": {
+				"@wordpress/element": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.2.0.tgz",
+					"integrity": "sha512-YXJhtBF8FnFYwA9X6Dvs4k6yJf5wy1lhU04VNJVzoUDwCt/pK747RGePIPDdUWVd3X/TlyNH2yLRtcCyOC/SzQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^2.2.0",
+						"lodash": "^4.17.21",
+						"react": "^17.0.1",
+						"react-dom": "^17.0.1"
+					}
+				}
+			}
+		},
+		"@types/wordpress__data": {
+			"version": "4.6.10",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__data/-/wordpress__data-4.6.10.tgz",
+			"integrity": "sha512-I5p1MnQpx4MM+/nYeThuCfuWXtHPt5zTrCaNPZWVsLQCwpUNMWxddCG4iXbh1uR1teSeEi8OAH6ozNxD1mm81Q==",
+			"dev": true,
+			"requires": {
+				"@types/react": "*",
+				"redux": "^4.0.1"
+			}
+		},
+		"@types/wordpress__keycodes": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__keycodes/-/wordpress__keycodes-2.3.1.tgz",
+			"integrity": "sha512-CUZv3WdPvWqnEwojbc4yEttwZlvsMGI8YurgB9CHVJXx6nQ4U2RU6PB0Mv7nxATufduFDMKq8TNpCHBenZqEjQ==",
+			"dev": true
+		},
+		"@types/wordpress__notices": {
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__notices/-/wordpress__notices-1.5.4.tgz",
+			"integrity": "sha512-JkWWwukEvv2o8xzyYXi5iveMgUnPZXIgQfw0u/IQkSZE8+1XTJgokLwo3Ks5PrWHEzlPCZXWQXQsGeShdoOkyQ==",
+			"dev": true,
+			"requires": {
+				"@types/react": "*",
+				"@types/wordpress__data": "*"
+			}
+		},
+		"@types/wordpress__rich-text": {
+			"version": "3.4.6",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__rich-text/-/wordpress__rich-text-3.4.6.tgz",
+			"integrity": "sha512-MeLSATBHrcN3fp8cVylbpx+BKRJ1aootPNtbTblcUAHcuRo6avKu1kaDLxIZb/8YbsD+/3Wm8d1uldeNz9/lhw==",
+			"dev": true,
+			"requires": {
+				"@types/react": "*",
+				"@types/wordpress__data": "*",
+				"@types/wordpress__rich-text": "*"
 			}
 		},
 		"@types/yargs": {
@@ -3809,6 +4000,34 @@
 				"prop-types": "^15.7.0"
 			}
 		},
+		"@wordpress/a11y": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-3.2.3.tgz",
+			"integrity": "sha512-s6ghUetvxRPDyC3fohaXtOeoTQeA1JPYPNSic616LWLWvx/bOCY4RibfwxS7p7prY1+0Px2VhxsPIM2kZuR/wA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/dom-ready": "^3.2.2",
+				"@wordpress/i18n": "^4.2.3"
+			}
+		},
+		"@wordpress/api-fetch": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-5.2.3.tgz",
+			"integrity": "sha512-hEGn9vXk76ejdvei1pBX/kaQ3xnKlE2dwtCXszgem8PdDF5GYzgESEwYaWvfgPAfJs7xF283FN1QsNzA4M+N9A==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/i18n": "^4.2.3",
+				"@wordpress/url": "^3.2.3"
+			}
+		},
+		"@wordpress/autop": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.2.2.tgz",
+			"integrity": "sha512-lfw7yZs1PeWVdPnKaV5rPMGIhkwPmdnKaviIbQV48E8irQOcPaT3NgWQksizr1Qlersm6aNBkXZfM1idRzzcgA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-3.1.0.tgz",
@@ -3841,11 +4060,431 @@
 			"integrity": "sha512-fwwDtCO2bt6v+kYE2iNrYaVg1u6iPgipWozS3OrMnZGdT6kmx8K7IGSP+s2zjfrtmJKfdRiJqRnGtKnbcJdxuQ==",
 			"dev": true
 		},
+		"@wordpress/blob": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.2.1.tgz",
+			"integrity": "sha512-qD8wZ6n+hjoshV2dp9eGH3VismOM0kvrJn5cSe4PaoYDREqUhioJIDXktZxaohnvgWOq6xfJH6rS4Or8W0r9ew==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"@wordpress/block-editor": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-6.2.0.tgz",
+			"integrity": "sha512-9jSpF2c6GN95g/Mt3XTNb9GF9irpv4sEaaH5KicvP9JTE1/AZcPG43HOoX+nYoiCwCu45BbAWnisJa7stvMMbw==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/a11y": "^3.2.0",
+				"@wordpress/blob": "^3.2.0",
+				"@wordpress/block-serialization-default-parser": "^4.2.0",
+				"@wordpress/blocks": "^10.0.0",
+				"@wordpress/components": "^14.2.0",
+				"@wordpress/compose": "^4.2.0",
+				"@wordpress/data": "^5.2.0",
+				"@wordpress/data-controls": "^2.2.0",
+				"@wordpress/deprecated": "^3.2.0",
+				"@wordpress/dom": "^3.2.0",
+				"@wordpress/element": "^3.2.0",
+				"@wordpress/hooks": "^3.2.0",
+				"@wordpress/html-entities": "^3.2.0",
+				"@wordpress/i18n": "^4.2.0",
+				"@wordpress/icons": "^4.1.0",
+				"@wordpress/is-shallow-equal": "^4.2.0",
+				"@wordpress/keyboard-shortcuts": "^2.2.0",
+				"@wordpress/keycodes": "^3.2.0",
+				"@wordpress/notices": "^3.2.0",
+				"@wordpress/rich-text": "^4.2.0",
+				"@wordpress/shortcode": "^3.2.0",
+				"@wordpress/token-list": "^2.2.0",
+				"@wordpress/url": "^3.2.0",
+				"@wordpress/warning": "^2.2.0",
+				"@wordpress/wordcount": "^3.2.0",
+				"classnames": "^2.3.1",
+				"css-mediaquery": "^0.1.2",
+				"diff": "^4.0.2",
+				"dom-scroll-into-view": "^1.2.1",
+				"inherits": "^2.0.3",
+				"lodash": "^4.17.21",
+				"memize": "^1.1.0",
+				"react-autosize-textarea": "^7.1.0",
+				"react-spring": "^8.0.19",
+				"redux-multi": "^0.1.12",
+				"rememo": "^3.0.0",
+				"tinycolor2": "^1.4.2",
+				"traverse": "^0.6.6"
+			},
+			"dependencies": {
+				"@wordpress/blocks": {
+					"version": "10.0.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-10.0.0.tgz",
+					"integrity": "sha512-AiCaU0BQQnMRI5ZvClbI4zXAI3PZ+agtKoJLSkFP9gZrffWcptOsZqnGu7NVoNkPT47PwJtImCLh1j3JSSAFvg==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/autop": "^3.2.0",
+						"@wordpress/blob": "^3.2.0",
+						"@wordpress/block-serialization-default-parser": "^4.2.0",
+						"@wordpress/compose": "^4.2.0",
+						"@wordpress/data": "^5.2.0",
+						"@wordpress/deprecated": "^3.2.0",
+						"@wordpress/dom": "^3.2.0",
+						"@wordpress/element": "^3.2.0",
+						"@wordpress/hooks": "^3.2.0",
+						"@wordpress/html-entities": "^3.2.0",
+						"@wordpress/i18n": "^4.2.0",
+						"@wordpress/icons": "^4.1.0",
+						"@wordpress/is-shallow-equal": "^4.2.0",
+						"@wordpress/shortcode": "^3.2.0",
+						"hpq": "^1.3.0",
+						"lodash": "^4.17.21",
+						"rememo": "^3.0.0",
+						"showdown": "^1.9.1",
+						"simple-html-tokenizer": "^0.5.7",
+						"tinycolor2": "^1.4.2",
+						"uuid": "^8.3.0"
+					}
+				},
+				"@wordpress/element": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.2.0.tgz",
+					"integrity": "sha512-YXJhtBF8FnFYwA9X6Dvs4k6yJf5wy1lhU04VNJVzoUDwCt/pK747RGePIPDdUWVd3X/TlyNH2yLRtcCyOC/SzQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^2.2.0",
+						"lodash": "^4.17.21",
+						"react": "^17.0.1",
+						"react-dom": "^17.0.1"
+					}
+				}
+			}
+		},
+		"@wordpress/block-serialization-default-parser": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.2.2.tgz",
+			"integrity": "sha512-XLig548y+chFJTmjrJptiEwZuMHpz7azIpoZssedGxP1ibffo8GV1VnKzGtr/P+Z/1PHt1L00pQgxtAZmKKBag==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"@wordpress/blocks": {
+			"version": "9.1.8",
+			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-9.1.8.tgz",
+			"integrity": "sha512-RYemYN+q5/M0k5mESBkQbsB101p9hWSOTSlGLzEPBj7yXJp/OnyQVdc2hAr6CQgX16CxOyRRXx1CYQdiOtXGYg==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/autop": "^3.1.2",
+				"@wordpress/blob": "^3.1.2",
+				"@wordpress/block-serialization-default-parser": "^4.1.2",
+				"@wordpress/compose": "^4.1.6",
+				"@wordpress/data": "^5.1.6",
+				"@wordpress/deprecated": "^3.1.2",
+				"@wordpress/dom": "^3.1.5",
+				"@wordpress/element": "^3.1.2",
+				"@wordpress/hooks": "^3.1.1",
+				"@wordpress/html-entities": "^3.1.2",
+				"@wordpress/i18n": "^4.1.2",
+				"@wordpress/icons": "^4.0.3",
+				"@wordpress/is-shallow-equal": "^4.1.1",
+				"@wordpress/shortcode": "^3.1.2",
+				"hpq": "^1.3.0",
+				"lodash": "^4.17.21",
+				"rememo": "^3.0.0",
+				"showdown": "^1.9.1",
+				"simple-html-tokenizer": "^0.5.7",
+				"tinycolor2": "^1.4.2",
+				"uuid": "^8.3.0"
+			},
+			"dependencies": {
+				"@wordpress/element": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.2.0.tgz",
+					"integrity": "sha512-YXJhtBF8FnFYwA9X6Dvs4k6yJf5wy1lhU04VNJVzoUDwCt/pK747RGePIPDdUWVd3X/TlyNH2yLRtcCyOC/SzQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^2.2.0",
+						"lodash": "^4.17.21",
+						"react": "^17.0.1",
+						"react-dom": "^17.0.1"
+					}
+				}
+			}
+		},
 		"@wordpress/browserslist-config": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-4.1.0.tgz",
 			"integrity": "sha512-RSJhgY2xmz6yAdDNhz/NvAO6JS+91vv9cVL7VDG2CftbyjTXBef05vWt3FzZhfeF0xUrYdpZL1PVpxmJiKvbEg==",
 			"dev": true
+		},
+		"@wordpress/components": {
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-14.2.0.tgz",
+			"integrity": "sha512-a06jjuBQMcIyrfXBfk4Hyu9BLQkT1rQm3tbOIE9Ur/cV8K0os0DrMUPZlNZ37IeOORzXhz89/L5mopvRttGLJQ==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@emotion/cache": "^11.1.3",
+				"@emotion/css": "^11.1.3",
+				"@emotion/react": "^11.1.5",
+				"@emotion/styled": "^11.3.0",
+				"@emotion/utils": "1.0.0",
+				"@wordpress/a11y": "^3.2.0",
+				"@wordpress/compose": "^4.2.0",
+				"@wordpress/date": "^4.2.0",
+				"@wordpress/deprecated": "^3.2.0",
+				"@wordpress/dom": "^3.2.0",
+				"@wordpress/element": "^3.2.0",
+				"@wordpress/hooks": "^3.2.0",
+				"@wordpress/i18n": "^4.2.0",
+				"@wordpress/icons": "^4.1.0",
+				"@wordpress/is-shallow-equal": "^4.2.0",
+				"@wordpress/keycodes": "^3.2.0",
+				"@wordpress/primitives": "^2.2.0",
+				"@wordpress/rich-text": "^4.2.0",
+				"@wordpress/warning": "^2.2.0",
+				"classnames": "^2.3.1",
+				"dom-scroll-into-view": "^1.2.1",
+				"downshift": "^6.0.15",
+				"gradient-parser": "^0.1.5",
+				"highlight-words-core": "^1.2.2",
+				"lodash": "^4.17.21",
+				"memize": "^1.1.0",
+				"moment": "^2.22.1",
+				"re-resizable": "^6.4.0",
+				"react-dates": "^17.1.1",
+				"react-resize-aware": "^3.1.0",
+				"react-spring": "^8.0.20",
+				"react-use-gesture": "^9.0.0",
+				"reakit": "^1.3.8",
+				"rememo": "^3.0.0",
+				"tinycolor2": "^1.4.2",
+				"uuid": "^8.3.0"
+			},
+			"dependencies": {
+				"@wordpress/element": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.2.0.tgz",
+					"integrity": "sha512-YXJhtBF8FnFYwA9X6Dvs4k6yJf5wy1lhU04VNJVzoUDwCt/pK747RGePIPDdUWVd3X/TlyNH2yLRtcCyOC/SzQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^2.2.0",
+						"lodash": "^4.17.21",
+						"react": "^17.0.1",
+						"react-dom": "^17.0.1"
+					}
+				}
+			}
+		},
+		"@wordpress/compose": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-4.2.0.tgz",
+			"integrity": "sha512-8CJ4wzTXT9ZP+uIvN1d2cPBv06ZmhUh+UKzSf7v1o7T28SaYRcoZbsvDD2dnXbS2ZwWPIYAD9waNLWjCBq/izA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@types/lodash": "4.14.149",
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^3.2.0",
+				"@wordpress/dom": "^3.2.0",
+				"@wordpress/element": "^3.2.0",
+				"@wordpress/is-shallow-equal": "^4.2.0",
+				"@wordpress/keycodes": "^3.2.0",
+				"@wordpress/priority-queue": "^2.2.0",
+				"clipboard": "^2.0.1",
+				"lodash": "^4.17.21",
+				"mousetrap": "^1.6.5",
+				"react-resize-aware": "^3.1.0",
+				"use-memo-one": "^1.1.1"
+			},
+			"dependencies": {
+				"@wordpress/element": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.2.0.tgz",
+					"integrity": "sha512-YXJhtBF8FnFYwA9X6Dvs4k6yJf5wy1lhU04VNJVzoUDwCt/pK747RGePIPDdUWVd3X/TlyNH2yLRtcCyOC/SzQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^2.2.0",
+						"lodash": "^4.17.21",
+						"react": "^17.0.1",
+						"react-dom": "^17.0.1"
+					}
+				}
+			}
+		},
+		"@wordpress/core-data": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-3.2.0.tgz",
+			"integrity": "sha512-YZCvNpumxegXM4emyuiSg+aUx9Xk2ElV7RqpmJFm04Tgw+ekli2WDTjt3B5q0HG8UUaSlwfIRvzka6BRYOrlCQ==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/api-fetch": "^5.2.0",
+				"@wordpress/blocks": "^10.0.0",
+				"@wordpress/data": "^5.2.0",
+				"@wordpress/data-controls": "^2.2.0",
+				"@wordpress/element": "^3.2.0",
+				"@wordpress/html-entities": "^3.2.0",
+				"@wordpress/i18n": "^4.2.0",
+				"@wordpress/is-shallow-equal": "^4.2.0",
+				"@wordpress/url": "^3.2.0",
+				"equivalent-key-map": "^0.2.2",
+				"lodash": "^4.17.21",
+				"rememo": "^3.0.0",
+				"uuid": "^8.3.0"
+			},
+			"dependencies": {
+				"@wordpress/blocks": {
+					"version": "10.0.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-10.0.0.tgz",
+					"integrity": "sha512-AiCaU0BQQnMRI5ZvClbI4zXAI3PZ+agtKoJLSkFP9gZrffWcptOsZqnGu7NVoNkPT47PwJtImCLh1j3JSSAFvg==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/autop": "^3.2.0",
+						"@wordpress/blob": "^3.2.0",
+						"@wordpress/block-serialization-default-parser": "^4.2.0",
+						"@wordpress/compose": "^4.2.0",
+						"@wordpress/data": "^5.2.0",
+						"@wordpress/deprecated": "^3.2.0",
+						"@wordpress/dom": "^3.2.0",
+						"@wordpress/element": "^3.2.0",
+						"@wordpress/hooks": "^3.2.0",
+						"@wordpress/html-entities": "^3.2.0",
+						"@wordpress/i18n": "^4.2.0",
+						"@wordpress/icons": "^4.1.0",
+						"@wordpress/is-shallow-equal": "^4.2.0",
+						"@wordpress/shortcode": "^3.2.0",
+						"hpq": "^1.3.0",
+						"lodash": "^4.17.21",
+						"rememo": "^3.0.0",
+						"showdown": "^1.9.1",
+						"simple-html-tokenizer": "^0.5.7",
+						"tinycolor2": "^1.4.2",
+						"uuid": "^8.3.0"
+					}
+				},
+				"@wordpress/element": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.2.0.tgz",
+					"integrity": "sha512-YXJhtBF8FnFYwA9X6Dvs4k6yJf5wy1lhU04VNJVzoUDwCt/pK747RGePIPDdUWVd3X/TlyNH2yLRtcCyOC/SzQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^2.2.0",
+						"lodash": "^4.17.21",
+						"react": "^17.0.1",
+						"react-dom": "^17.0.1"
+					}
+				}
+			}
+		},
+		"@wordpress/data": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-5.2.0.tgz",
+			"integrity": "sha512-NlPIC8PdKnPly9CnynQS1di59Af3eiCZrQgZm1VssfA620NDoJA5p3dlDYj/Ts4Ryzp78HCi7wjhkmbsHpnd6g==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/compose": "^4.2.0",
+				"@wordpress/deprecated": "^3.2.0",
+				"@wordpress/element": "^3.2.0",
+				"@wordpress/is-shallow-equal": "^4.2.0",
+				"@wordpress/priority-queue": "^2.2.0",
+				"@wordpress/redux-routine": "^4.2.0",
+				"equivalent-key-map": "^0.2.2",
+				"is-promise": "^4.0.0",
+				"lodash": "^4.17.21",
+				"memize": "^1.1.0",
+				"turbo-combine-reducers": "^1.0.2",
+				"use-memo-one": "^1.1.1"
+			},
+			"dependencies": {
+				"@wordpress/element": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.2.0.tgz",
+					"integrity": "sha512-YXJhtBF8FnFYwA9X6Dvs4k6yJf5wy1lhU04VNJVzoUDwCt/pK747RGePIPDdUWVd3X/TlyNH2yLRtcCyOC/SzQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^2.2.0",
+						"lodash": "^4.17.21",
+						"react": "^17.0.1",
+						"react-dom": "^17.0.1"
+					}
+				}
+			}
+		},
+		"@wordpress/data-controls": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/data-controls/-/data-controls-2.2.4.tgz",
+			"integrity": "sha512-JG8vJIEdmDfbdUpKaz4AyTlQNe/oV1i6dteCIKk5VI6QE+Zl9nWkDJMYpsqrD3TG+F7tdHLcMJCZC/NtGWgQBQ==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/api-fetch": "^5.2.3",
+				"@wordpress/data": "^6.1.1",
+				"@wordpress/deprecated": "^3.2.2"
+			},
+			"dependencies": {
+				"@types/lodash": {
+					"version": "4.14.175",
+					"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.175.tgz",
+					"integrity": "sha512-XmdEOrKQ8a1Y/yxQFOMbC47G/V2VDO1GvMRnl4O75M4GW/abC5tnfzadQYkqEveqRM1dEJGFFegfPNA2vvx2iw=="
+				},
+				"@wordpress/compose": {
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.3.tgz",
+					"integrity": "sha512-uRd4tBp2+FWorLuoec3CyoizgnlbrxvAyPx+it7+OmzP+/Lz6rRYkymaFDA/XTh2umkjYT8pK7FQP1H8+DfqVA==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/lodash": "^4.14.172",
+						"@types/mousetrap": "^1.6.8",
+						"@wordpress/deprecated": "^3.2.2",
+						"@wordpress/dom": "^3.2.4",
+						"@wordpress/element": "^4.0.2",
+						"@wordpress/is-shallow-equal": "^4.2.0",
+						"@wordpress/keycodes": "^3.2.3",
+						"@wordpress/priority-queue": "^2.2.2",
+						"clipboard": "^2.0.8",
+						"lodash": "^4.17.21",
+						"mousetrap": "^1.6.5",
+						"react-resize-aware": "^3.1.0",
+						"use-memo-one": "^1.1.1"
+					}
+				},
+				"@wordpress/data": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.1.1.tgz",
+					"integrity": "sha512-I+kvY2aMA4Ec62rZCS4vUKRalZ01qiBTkEQXash+usYH3Lsyi6rULekwUZ9zcisVpWYbaLZsrmmarCusS65KTg==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/compose": "^5.0.3",
+						"@wordpress/deprecated": "^3.2.2",
+						"@wordpress/element": "^4.0.2",
+						"@wordpress/is-shallow-equal": "^4.2.0",
+						"@wordpress/priority-queue": "^2.2.2",
+						"@wordpress/redux-routine": "^4.2.1",
+						"equivalent-key-map": "^0.2.2",
+						"is-promise": "^4.0.0",
+						"lodash": "^4.17.21",
+						"memize": "^1.1.0",
+						"turbo-combine-reducers": "^1.0.2",
+						"use-memo-one": "^1.1.1"
+					}
+				}
+			}
+		},
+		"@wordpress/date": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.2.2.tgz",
+			"integrity": "sha512-sYcMvFwrVoYv5lL9NsYLVd29hfuqgf1L1WsIjDV8hMna1eqr9f8xCrZSLgBKkDBmVWiIcleYGP5uDdrKpu6EiA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"moment": "^2.22.1",
+				"moment-timezone": "^0.5.31"
+			}
 		},
 		"@wordpress/dependency-extraction-webpack-plugin": {
 			"version": "3.2.1",
@@ -3855,6 +4494,32 @@
 			"requires": {
 				"json2php": "^0.0.4",
 				"webpack-sources": "^2.2.0"
+			}
+		},
+		"@wordpress/deprecated": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.2.2.tgz",
+			"integrity": "sha512-htsu2zJUuGYG1+jejAi0r25bQQOT3bB0MGjoSixqZ0sRkFMRIdjmMLrSbpGrl0s5IRK2/w/slsStPFmm3reJtA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/hooks": "^3.2.1"
+			}
+		},
+		"@wordpress/dom": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.2.4.tgz",
+			"integrity": "sha512-VQ7ZCyP7/cSWK8QdqQnrgaiM32/kFm/geN4F84AkFj9ZyYuhI13I631uoe5SDXtn1PD3Mr6JNTyLXcJFWbnY2g==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"lodash": "^4.17.21"
+			}
+		},
+		"@wordpress/dom-ready": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-3.2.2.tgz",
+			"integrity": "sha512-yCpm/vG3GanhhACnpbc7GZ2sv6oSHIkTxNPgejA5Z8cr0mEc6irsWDzhEHKcP3OhSina++IZ9ZidO7JH7eE2Xg==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
 			}
 		},
 		"@wordpress/element": {
@@ -3940,14 +4605,75 @@
 				}
 			}
 		},
-		"@wordpress/icons": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-6.0.0.tgz",
-			"integrity": "sha512-dLr7O2mu6JlCQhM3uSIRJHFyv1AeYpRosrcWF9+zlhUy7RBczfLfhf7lXO6gVxhyuUEiWYfvesB5pNha4HxsVg==",
+		"@wordpress/hooks": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.2.1.tgz",
+			"integrity": "sha512-yI8MHs6UsvgJdDsOnXGkY7/7hrOCEv/M7vwdEVA5r6nGzgJaJxf8pjBqzRkCq3nVaWqxoNZgCMHJSul6Q8RR2g==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"@wordpress/html-entities": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-3.2.2.tgz",
+			"integrity": "sha512-MsmB1wtDMFfvNQiKMVMW+1ie2P3+tBZiHESkDPnXw34Dt4Tk0+QY7eYCR9krNcjJImWYJcxL+4n4M1OF9oQv0Q==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"@wordpress/i18n": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.2.3.tgz",
+			"integrity": "sha512-iaL7WVmFBVLyUJR0FVeaI0YJK3BiYg6Ir+s3PoJN3ppm+YsZUGThstHL8zSfQFMF0WaQ0OFWjnDqNl1th2annA==",
 			"requires": {
 				"@babel/runtime": "^7.13.10",
-				"@wordpress/element": "^4.0.2",
-				"@wordpress/primitives": "^3.0.2"
+				"@wordpress/hooks": "^3.2.1",
+				"gettext-parser": "^1.3.1",
+				"lodash": "^4.17.21",
+				"memize": "^1.1.0",
+				"sprintf-js": "^1.1.1",
+				"tannin": "^1.2.0"
+			},
+			"dependencies": {
+				"sprintf-js": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+				}
+			}
+		},
+		"@wordpress/icons": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-4.1.0.tgz",
+			"integrity": "sha512-1FpEjT9kJbr0cWbgdgIwd2DoeerWijcVx3qCZ/WMFKNElBH9lfZLuWPI1hpX102HGWFcEi3VlbVpdBGeCeYQWg==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/element": "^3.2.0",
+				"@wordpress/primitives": "^2.2.0"
+			},
+			"dependencies": {
+				"@wordpress/element": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.2.0.tgz",
+					"integrity": "sha512-YXJhtBF8FnFYwA9X6Dvs4k6yJf5wy1lhU04VNJVzoUDwCt/pK747RGePIPDdUWVd3X/TlyNH2yLRtcCyOC/SzQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^2.2.0",
+						"lodash": "^4.17.21",
+						"react": "^17.0.1",
+						"react-dom": "^17.0.1"
+					}
+				}
+			}
+		},
+		"@wordpress/is-shallow-equal": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.2.0.tgz",
+			"integrity": "sha512-9Oy7f3HFLMNfry4LLwYmfx4tROmusPAOfanv9F/MgzSBfMH7eyxU2JZd4KrP7IbPb59UfoUa8GhaLsnqKm66og==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
 			}
 		},
 		"@wordpress/jest-console": {
@@ -3974,6 +4700,105 @@
 				"enzyme-to-json": "^3.4.4"
 			}
 		},
+		"@wordpress/keyboard-shortcuts": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-2.2.0.tgz",
+			"integrity": "sha512-YSp6jkpsLGQAMwU0l400/t/kmronvdvTWzXuHolSktcy4uklg+yJjmufzGv7W22rdrjR8FmBEDST9jtFgZxjyA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/compose": "^4.2.0",
+				"@wordpress/data": "^5.2.0",
+				"@wordpress/element": "^3.2.0",
+				"@wordpress/keycodes": "^3.2.0",
+				"lodash": "^4.17.21",
+				"rememo": "^3.0.0"
+			},
+			"dependencies": {
+				"@wordpress/element": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.2.0.tgz",
+					"integrity": "sha512-YXJhtBF8FnFYwA9X6Dvs4k6yJf5wy1lhU04VNJVzoUDwCt/pK747RGePIPDdUWVd3X/TlyNH2yLRtcCyOC/SzQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^2.2.0",
+						"lodash": "^4.17.21",
+						"react": "^17.0.1",
+						"react-dom": "^17.0.1"
+					}
+				}
+			}
+		},
+		"@wordpress/keycodes": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.2.3.tgz",
+			"integrity": "sha512-1ClhtTbOSijLsyubbTlg1Df++W4CmjjRj88L7rzGX63iEHfBX6SSvui2pWVlQigDNdLNoaYGOaWm5eqDnvxkeQ==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/i18n": "^4.2.3",
+				"lodash": "^4.17.21"
+			}
+		},
+		"@wordpress/notices": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-3.2.4.tgz",
+			"integrity": "sha512-YpzgJwKwoO6SwCwu33jAr5FzaI9EezTKSu1VMZ/CQh4HNlnZxUSx/H+JDoUzHQWdHF3Z7EWiPBy8rZQVzFVaLw==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/a11y": "^3.2.3",
+				"@wordpress/data": "^6.1.1",
+				"lodash": "^4.17.21"
+			},
+			"dependencies": {
+				"@types/lodash": {
+					"version": "4.14.175",
+					"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.175.tgz",
+					"integrity": "sha512-XmdEOrKQ8a1Y/yxQFOMbC47G/V2VDO1GvMRnl4O75M4GW/abC5tnfzadQYkqEveqRM1dEJGFFegfPNA2vvx2iw=="
+				},
+				"@wordpress/compose": {
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.3.tgz",
+					"integrity": "sha512-uRd4tBp2+FWorLuoec3CyoizgnlbrxvAyPx+it7+OmzP+/Lz6rRYkymaFDA/XTh2umkjYT8pK7FQP1H8+DfqVA==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/lodash": "^4.14.172",
+						"@types/mousetrap": "^1.6.8",
+						"@wordpress/deprecated": "^3.2.2",
+						"@wordpress/dom": "^3.2.4",
+						"@wordpress/element": "^4.0.2",
+						"@wordpress/is-shallow-equal": "^4.2.0",
+						"@wordpress/keycodes": "^3.2.3",
+						"@wordpress/priority-queue": "^2.2.2",
+						"clipboard": "^2.0.8",
+						"lodash": "^4.17.21",
+						"mousetrap": "^1.6.5",
+						"react-resize-aware": "^3.1.0",
+						"use-memo-one": "^1.1.1"
+					}
+				},
+				"@wordpress/data": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.1.1.tgz",
+					"integrity": "sha512-I+kvY2aMA4Ec62rZCS4vUKRalZ01qiBTkEQXash+usYH3Lsyi6rULekwUZ9zcisVpWYbaLZsrmmarCusS65KTg==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/compose": "^5.0.3",
+						"@wordpress/deprecated": "^3.2.2",
+						"@wordpress/element": "^4.0.2",
+						"@wordpress/is-shallow-equal": "^4.2.0",
+						"@wordpress/priority-queue": "^2.2.2",
+						"@wordpress/redux-routine": "^4.2.1",
+						"equivalent-key-map": "^0.2.2",
+						"is-promise": "^4.0.0",
+						"lodash": "^4.17.21",
+						"memize": "^1.1.0",
+						"turbo-combine-reducers": "^1.0.2",
+						"use-memo-one": "^1.1.1"
+					}
+				}
+			}
+		},
 		"@wordpress/npm-package-json-lint-config": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.1.0.tgz",
@@ -3997,13 +4822,84 @@
 			"dev": true
 		},
 		"@wordpress/primitives": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-3.0.2.tgz",
-			"integrity": "sha512-/r7EuKEyzM8aPhjGS/NC1+lgr3Dk/mCbICndAh7sZP86OmWqoSpnh0VPZp/DxT4JdGiCa/NycXdOiP7ylngG6A==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-2.2.0.tgz",
+			"integrity": "sha512-WupgR+tt6fKGZE1UKy2gz3wDdpRL9MWQbVuetXv/7TPAz2ofOS2fZIsXNrl4D0HkA82gYh8w8s2TXK0XNyAAow==",
 			"requires": {
 				"@babel/runtime": "^7.13.10",
-				"@wordpress/element": "^4.0.2",
+				"@wordpress/element": "^3.2.0",
 				"classnames": "^2.3.1"
+			},
+			"dependencies": {
+				"@wordpress/element": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.2.0.tgz",
+					"integrity": "sha512-YXJhtBF8FnFYwA9X6Dvs4k6yJf5wy1lhU04VNJVzoUDwCt/pK747RGePIPDdUWVd3X/TlyNH2yLRtcCyOC/SzQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^2.2.0",
+						"lodash": "^4.17.21",
+						"react": "^17.0.1",
+						"react-dom": "^17.0.1"
+					}
+				}
+			}
+		},
+		"@wordpress/priority-queue": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.2.2.tgz",
+			"integrity": "sha512-28zPQ1jIhM+9w0xfLzL8xoHIEyG0ORjIi4A8j3aWBYXHYH9f/7oVAtJRXgVTJ9iJFyiUTL8sDiaZQ6aTFV78Tg==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"@wordpress/redux-routine": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.2.1.tgz",
+			"integrity": "sha512-u//4vdeKzYvu4YBRmSUsIbnUazai+PybEnquLPqxQdaF4JqVN1D5OPWHSeFtmaXR1c78I+lUf40Q7dnmA2waXw==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"is-promise": "^4.0.0",
+				"lodash": "^4.17.21",
+				"redux": "^4.1.0",
+				"rungen": "^0.3.2"
+			}
+		},
+		"@wordpress/rich-text": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-4.2.0.tgz",
+			"integrity": "sha512-e+wfrkKtZIcFZJZLxkrikiXbxlr6nuGg+V94uKMLrzJEWdw7w/8l3dNhWHRGPkldXIEGrF/mV40ibjUa2p3Sfg==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/compose": "^4.2.0",
+				"@wordpress/data": "^5.2.0",
+				"@wordpress/dom": "^3.2.0",
+				"@wordpress/element": "^3.2.0",
+				"@wordpress/escape-html": "^2.2.0",
+				"@wordpress/is-shallow-equal": "^4.2.0",
+				"@wordpress/keycodes": "^3.2.0",
+				"classnames": "^2.3.1",
+				"lodash": "^4.17.21",
+				"memize": "^1.1.0",
+				"rememo": "^3.0.0"
+			},
+			"dependencies": {
+				"@wordpress/element": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.2.0.tgz",
+					"integrity": "sha512-YXJhtBF8FnFYwA9X6Dvs4k6yJf5wy1lhU04VNJVzoUDwCt/pK747RGePIPDdUWVd3X/TlyNH2yLRtcCyOC/SzQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^2.2.0",
+						"lodash": "^4.17.21",
+						"react": "^17.0.1",
+						"react-dom": "^17.0.1"
+					}
+				}
 			}
 		},
 		"@wordpress/scripts": {
@@ -4065,6 +4961,16 @@
 				"webpack-livereload-plugin": "^3.0.1"
 			}
 		},
+		"@wordpress/shortcode": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.2.2.tgz",
+			"integrity": "sha512-Im3z6C/+0IYepBg7w3m+2wyAEQfNLoWN3yQ1czNPsGHMAbELvAZjhd9S1hkJXgdyS9wQnamIQhu9wGB20qeh9A==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"lodash": "^4.17.21",
+				"memize": "^1.1.0"
+			}
+		},
 		"@wordpress/stylelint-config": {
 			"version": "19.1.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-19.1.0.tgz",
@@ -4076,11 +4982,37 @@
 				"stylelint-scss": "^3.17.2"
 			}
 		},
+		"@wordpress/token-list": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-2.2.1.tgz",
+			"integrity": "sha512-SBFATG3F6WcnRzcuu396KhesXI36qkzq21JV653+4XOwLsSVSEVbec2cFHw5WCvrj3Oe7Sv7hRK9Ia/wBW7bzA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"lodash": "^4.17.21"
+			}
+		},
+		"@wordpress/url": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.2.3.tgz",
+			"integrity": "sha512-sepFDMcshaLBEPHDuHDAsXWsrRInyOa3an3Y8OfqLFwAoMZGAKJTClx1k4DnJwRRGhjv03veTl0IqxTdMH/CiA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"lodash": "^4.17.21"
+			}
+		},
 		"@wordpress/warning": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.2.2.tgz",
-			"integrity": "sha512-iG1Hq56RK3N6AJqAD1sRLWRIJatfYn+NrPyrfqRNZNYXHM8Vj/s7ABNMbIU0Y99vXkBE83rvCdbMkugNoI2jXA==",
-			"dev": true
+			"integrity": "sha512-iG1Hq56RK3N6AJqAD1sRLWRIJatfYn+NrPyrfqRNZNYXHM8Vj/s7ABNMbIU0Y99vXkBE83rvCdbMkugNoI2jXA=="
+		},
+		"@wordpress/wordcount": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-3.2.2.tgz",
+			"integrity": "sha512-lb0gpBmdbGhaVET8eUqa/PwVOlFcJc0gtsiOzUGq2GlDSqoC/ouE5dj1R9Dw68ybiD1pmEPDRArU4fF0JSNsfA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"lodash": "^4.17.21"
+			}
 		},
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
@@ -4158,6 +5090,22 @@
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				}
+			}
+		},
+		"airbnb-prop-types": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz",
+			"integrity": "sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==",
+			"requires": {
+				"array.prototype.find": "^2.1.1",
+				"function.prototype.name": "^1.1.2",
+				"is-regex": "^1.1.0",
+				"object-is": "^1.1.2",
+				"object.assign": "^4.1.0",
+				"object.entries": "^1.1.2",
+				"prop-types": "^15.7.2",
+				"prop-types-exact": "^1.2.0",
+				"react-is": "^16.13.1"
 			}
 		},
 		"ajv": {
@@ -4325,11 +5273,20 @@
 				"is-string": "^1.0.7"
 			}
 		},
+		"array.prototype.find": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.2.tgz",
+			"integrity": "sha512-00S1O4ewO95OmmJW7EesWfQlrCrLEL8kZ40w3+GkLX2yTt0m2ggcePPa2uHPJ9KUmJvwRq+lCV9bD8Yim23x/Q==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.19.0"
+			}
+		},
 		"array.prototype.flat": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
 			"integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
@@ -4452,6 +5409,11 @@
 					"dev": true
 				}
 			}
+		},
+		"autosize": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.4.tgz",
+			"integrity": "sha512-5yxLQ22O0fCRGoxGfeLSNt3J8LB1v+umtpMnPW6XjkTWXKoN0AmXAIhelJcDtFT/Y/wYWmfE+oqU10Q0b8FhaQ=="
 		},
 		"axe-core": {
 			"version": "4.3.3",
@@ -4785,6 +5747,11 @@
 				"safe-json-parse": "~1.0.1"
 			}
 		},
+		"body-scroll-lock": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz",
+			"integrity": "sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg=="
+		},
 		"boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -4809,6 +5776,11 @@
 			"requires": {
 				"fill-range": "^7.0.1"
 			}
+		},
+		"brcast": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brcast/-/brcast-2.0.2.tgz",
+			"integrity": "sha512-Tfn5JSE7hrUlFcOoaLzVvkbgIemIorMIyoMr3TgvszWW7jFt2C9PdeMLtysYD9RU0MmU17b69+XJG1eRY2OBRg=="
 		},
 		"browser-process-hrtime": {
 			"version": "1.0.0",
@@ -4912,7 +5884,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
 			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
 				"get-intrinsic": "^1.0.2"
@@ -4958,8 +5929,7 @@
 		"camelcase": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-			"dev": true
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 		},
 		"camelcase-keys": {
 			"version": "6.2.2",
@@ -5287,11 +6257,20 @@
 			"integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
 			"dev": true
 		},
+		"clipboard": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
+			"integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
+			"requires": {
+				"good-listener": "^1.2.2",
+				"select": "^1.1.2",
+				"tiny-emitter": "^2.0.0"
+			}
+		},
 		"cliui": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
 			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-			"dev": true,
 			"requires": {
 				"string-width": "^3.1.0",
 				"strip-ansi": "^5.2.0",
@@ -5301,26 +6280,22 @@
 				"ansi-regex": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
 				},
 				"emoji-regex": {
 					"version": "7.0.3",
 					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-					"dev": true
+					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 				},
 				"string-width": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
 					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
 					"requires": {
 						"emoji-regex": "^7.0.1",
 						"is-fullwidth-code-point": "^2.0.0",
@@ -5331,7 +6306,6 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
 					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^4.1.0"
 					}
@@ -5545,6 +6519,16 @@
 			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
 			"dev": true
 		},
+		"compute-scroll-into-view": {
+			"version": "1.0.17",
+			"resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
+			"integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg=="
+		},
+		"computed-style": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/computed-style/-/computed-style-0.1.4.tgz",
+			"integrity": "sha1-fzRP2FhLLkJb7cpKGvwOMAuwXXQ="
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5562,6 +6546,11 @@
 				"readable-stream": "^2.2.2",
 				"typedarray": "^0.0.6"
 			}
+		},
+		"consolidated-events": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/consolidated-events/-/consolidated-events-2.0.2.tgz",
+			"integrity": "sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ=="
 		},
 		"continuable-cache": {
 			"version": "0.3.1",
@@ -5739,6 +6728,11 @@
 					}
 				}
 			}
+		},
+		"css-mediaquery": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+			"integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA="
 		},
 		"css-select": {
 			"version": "2.1.0",
@@ -5952,8 +6946,7 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"decamelize-keys": {
 			"version": "1.1.0",
@@ -6037,7 +7030,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-			"dev": true,
 			"requires": {
 				"object-keys": "^1.0.12"
 			}
@@ -6151,6 +7143,11 @@
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
 		},
+		"delegate": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
+		},
 		"detect-newline": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -6162,6 +7159,11 @@
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.901419.tgz",
 			"integrity": "sha512-4INMPwNm9XRpBukhNbF7OB6fNTTCaI8pzy/fXg0xQzAy5h3zL1P8xT3QazgKqBrb/hAYwIBizqDBZ7GtJE74QQ==",
 			"dev": true
+		},
+		"diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
 		},
 		"diff-sequences": {
 			"version": "26.6.2",
@@ -6177,6 +7179,11 @@
 			"requires": {
 				"path-type": "^4.0.0"
 			}
+		},
+		"direction": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
+			"integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ=="
 		},
 		"discontinuous-range": {
 			"version": "1.0.0",
@@ -6198,6 +7205,19 @@
 			"requires": {
 				"esutils": "^2.0.2"
 			}
+		},
+		"document.contains": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/document.contains/-/document.contains-1.0.2.tgz",
+			"integrity": "sha512-YcvYFs15mX8m3AO1QNQy3BlIpSMfNRj3Ujk2BEJxsZG+HZf7/hZ6jr7mDpXrF8q+ff95Vef5yjhiZxm8CGJr6Q==",
+			"requires": {
+				"define-properties": "^1.1.3"
+			}
+		},
+		"dom-scroll-into-view": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-1.2.1.tgz",
+			"integrity": "sha1-6PNnMt0ImwIBqI14Fdw/iObWbH4="
 		},
 		"dom-serializer": {
 			"version": "0.2.2",
@@ -6276,6 +7296,30 @@
 				"is-obj": "^2.0.0"
 			}
 		},
+		"downshift": {
+			"version": "6.1.7",
+			"resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.7.tgz",
+			"integrity": "sha512-cVprZg/9Lvj/uhYRxELzlu1aezRcgPWBjTvspiGTVEU64gF5pRdSRKFVLcxqsZC637cLAGMbL40JavEfWnqgNg==",
+			"requires": {
+				"@babel/runtime": "^7.14.8",
+				"compute-scroll-into-view": "^1.0.17",
+				"prop-types": "^15.7.2",
+				"react-is": "^17.0.2",
+				"tslib": "^2.3.0"
+			},
+			"dependencies": {
+				"react-is": {
+					"version": "17.0.2",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+					"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+				},
+				"tslib": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+				}
+			}
+		},
 		"duplexer": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -6311,6 +7355,24 @@
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
 			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
 			"dev": true
+		},
+		"encoding": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+			"requires": {
+				"iconv-lite": "^0.6.2"
+			},
+			"dependencies": {
+				"iconv-lite": {
+					"version": "0.6.3",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+					"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3.0.0"
+					}
+				}
+			}
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
@@ -6403,6 +7465,11 @@
 				"react-is": "^16.12.0"
 			}
 		},
+		"equivalent-key-map": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.2.2.tgz",
+			"integrity": "sha512-xvHeyCDbZzkpN4VHQj/n+j2lOwL0VWszG30X4cOrc9Y7Tuo2qCdZK/0AMod23Z5dCtNUbaju6p0rwOhHUk05ew=="
+		},
 		"error": {
 			"version": "7.2.1",
 			"resolved": "https://registry.npmjs.org/error/-/error-7.2.1.tgz",
@@ -6424,7 +7491,6 @@
 			"version": "1.19.1",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
 			"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"es-to-primitive": "^1.2.1",
@@ -6464,7 +7530,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
 			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-			"dev": true,
 			"requires": {
 				"is-callable": "^1.1.4",
 				"is-date-object": "^1.0.1",
@@ -7398,6 +8463,11 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
+		"fast-memoize": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
+			"integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
+		},
 		"fastest-levenshtein": {
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
@@ -7608,7 +8678,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-			"dev": true,
 			"requires": {
 				"locate-path": "^3.0.0"
 			}
@@ -7710,7 +8779,6 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
 			"integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
@@ -7727,8 +8795,7 @@
 		"functions-have-names": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.2.tgz",
-			"integrity": "sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA==",
-			"dev": true
+			"integrity": "sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA=="
 		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
@@ -7739,14 +8806,12 @@
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-			"dev": true
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
 		},
 		"get-intrinsic": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
 			"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
@@ -7778,7 +8843,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
 			"integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"get-intrinsic": "^1.1.1"
@@ -7789,6 +8853,15 @@
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
 			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
 			"dev": true
+		},
+		"gettext-parser": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+			"integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+			"requires": {
+				"encoding": "^0.1.12",
+				"safe-buffer": "^5.1.1"
+			}
 		},
 		"glob": {
 			"version": "7.1.7",
@@ -7818,6 +8891,15 @@
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
 			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
 			"dev": true
+		},
+		"global-cache": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/global-cache/-/global-cache-1.2.1.tgz",
+			"integrity": "sha512-EOeUaup5DgWKlCMhA9YFqNRIlZwoxt731jCh47WBV9fQqHgXhr3Fa55hfgIUqilIcPsfdNKN7LHjrNY+Km40KA==",
+			"requires": {
+				"define-properties": "^1.1.2",
+				"is-symbol": "^1.0.1"
+			}
 		},
 		"global-modules": {
 			"version": "0.2.3",
@@ -7892,6 +8974,14 @@
 				"minimist": "^1.2.5"
 			}
 		},
+		"good-listener": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+			"integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+			"requires": {
+				"delegate": "^3.1.2"
+			}
+		},
 		"got": {
 			"version": "10.7.0",
 			"resolved": "https://registry.npmjs.org/got/-/got-10.7.0.tgz",
@@ -7920,6 +9010,11 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
 			"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
 			"dev": true
+		},
+		"gradient-parser": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-0.1.5.tgz",
+			"integrity": "sha1-DH4heVWeXOfY1x9EI6+TcQCyJIw="
 		},
 		"growly": {
 			"version": "1.3.0",
@@ -7954,8 +9049,7 @@
 		"has-bigints": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
-			"dev": true
+			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
 		},
 		"has-flag": {
 			"version": "4.0.0",
@@ -7966,14 +9060,12 @@
 		"has-symbols": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-			"dev": true
+			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
 		},
 		"has-tostringtag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
 			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-			"dev": true,
 			"requires": {
 				"has-symbols": "^1.0.2"
 			}
@@ -8030,6 +9122,11 @@
 				}
 			}
 		},
+		"highlight-words-core": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
+			"integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg=="
+		},
 		"hoist-non-react-statics": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -8052,6 +9149,11 @@
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
 			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 			"dev": true
+		},
+		"hpq": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/hpq/-/hpq-1.3.0.tgz",
+			"integrity": "sha512-fvYTvdCFOWQupGxqkahrkA+ERBuMdzkxwtUdKrxR6rmMd4Pfl+iZ1QiQYoaZ0B/v0y59MOMnz3XFUWbT50/NWA=="
 		},
 		"html-element-map": {
 			"version": "1.3.1",
@@ -8327,8 +9429,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"ini": {
 			"version": "1.3.8",
@@ -8361,7 +9462,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
 			"integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
-			"dev": true,
 			"requires": {
 				"get-intrinsic": "^1.1.0",
 				"has": "^1.0.3",
@@ -8437,7 +9537,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
 			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-			"dev": true,
 			"requires": {
 				"has-bigints": "^1.0.1"
 			}
@@ -8455,7 +9554,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
 			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
@@ -8470,8 +9568,7 @@
 		"is-callable": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-			"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
-			"dev": true
+			"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
 		},
 		"is-ci": {
 			"version": "2.0.0",
@@ -8514,7 +9611,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
 			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-			"dev": true,
 			"requires": {
 				"has-tostringtag": "^1.0.0"
 			}
@@ -8605,8 +9701,7 @@
 		"is-negative-zero": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-			"dev": true
+			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
 		},
 		"is-number": {
 			"version": "7.0.0",
@@ -8618,7 +9713,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
 			"integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
-			"dev": true,
 			"requires": {
 				"has-tostringtag": "^1.0.0"
 			}
@@ -8674,11 +9768,15 @@
 			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
 			"dev": true
 		},
+		"is-promise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+		},
 		"is-regex": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
 			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
@@ -8699,8 +9797,7 @@
 		"is-shared-array-buffer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-			"integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
-			"dev": true
+			"integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA=="
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -8712,7 +9809,6 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
 			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-			"dev": true,
 			"requires": {
 				"has-tostringtag": "^1.0.0"
 			}
@@ -8733,10 +9829,14 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
 			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-			"dev": true,
 			"requires": {
 				"has-symbols": "^1.0.2"
 			}
+		},
+		"is-touch-device": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-touch-device/-/is-touch-device-1.0.1.tgz",
+			"integrity": "sha512-LAYzo9kMT1b2p19L/1ATGt2XcSilnzNlyvq6c0pbPRVisLbAPpLqr53tIJS00kvrTkj0HtR8U7+u8X0yR8lPSw=="
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
@@ -8760,7 +9860,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
 			"integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.0"
 			}
@@ -9919,6 +11018,14 @@
 			"integrity": "sha512-EHKqr/+ZvdKCifpNrJCKxBTgk5XupZA3y/aCPY9mxfgBzmgh93Mt/WqjjQ38oMxXuvDokaKiM3lAgvSH2sjtHg==",
 			"dev": true
 		},
+		"line-height": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/line-height/-/line-height-0.3.1.tgz",
+			"integrity": "sha1-SxIF7d4YKHKl76PI9iCzGHqcVMk=",
+			"requires": {
+				"computed-style": "~0.1.3"
+			}
+		},
 		"lines-and-columns": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -9984,7 +11091,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-			"dev": true,
 			"requires": {
 				"p-locate": "^3.0.0",
 				"path-exists": "^3.0.0"
@@ -10365,6 +11471,11 @@
 			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
 			"dev": true
 		},
+		"memize": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+			"integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg=="
+		},
 		"meow": {
 			"version": "6.1.1",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-6.1.1.tgz",
@@ -10689,11 +11800,29 @@
 				"minimist": "^1.2.5"
 			}
 		},
+		"moment": {
+			"version": "2.29.1",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+			"integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+		},
+		"moment-timezone": {
+			"version": "0.5.33",
+			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
+			"integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
+			"requires": {
+				"moment": ">= 2.9.0"
+			}
+		},
 		"moo": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
 			"integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==",
 			"dev": true
+		},
+		"mousetrap": {
+			"version": "1.6.5",
+			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
+			"integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA=="
 		},
 		"ms": {
 			"version": "2.0.0",
@@ -11007,14 +12136,12 @@
 		"object-inspect": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-			"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
-			"dev": true
+			"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
 		},
 		"object-is": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
 			"integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3"
@@ -11023,8 +12150,7 @@
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"dev": true
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
 		},
 		"object-visit": {
 			"version": "1.0.1",
@@ -11039,7 +12165,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
 			"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
@@ -11051,7 +12176,6 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
 			"integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
@@ -11103,7 +12227,6 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
 			"integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
@@ -11219,7 +12342,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
 			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"dev": true,
 			"requires": {
 				"p-try": "^2.0.0"
 			}
@@ -11228,7 +12350,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-			"dev": true,
 			"requires": {
 				"p-limit": "^2.0.0"
 			}
@@ -11251,8 +12372,7 @@
 		"p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"dev": true
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 		},
 		"parent-module": {
 			"version": "1.0.1",
@@ -11323,8 +12443,7 @@
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
@@ -12744,11 +13863,20 @@
 			"version": "15.7.2",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
 			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
 				"react-is": "^16.8.1"
+			}
+		},
+		"prop-types-exact": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
+			"integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
+			"requires": {
+				"has": "^1.0.3",
+				"object.assign": "^4.1.0",
+				"reflect.ownkeys": "^0.2.0"
 			}
 		},
 		"proxy-from-env": {
@@ -12988,6 +14116,14 @@
 				}
 			}
 		},
+		"re-resizable": {
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.1.tgz",
+			"integrity": "sha512-KRYAgr9/j1PJ3K+t+MBhlQ+qkkoLDJ1rs0z1heIWvYbCW/9Vq4djDU+QumJ3hQbwwtzXF6OInla6rOx6hhgRhQ==",
+			"requires": {
+				"fast-memoize": "^2.5.1"
+			}
+		},
 		"react": {
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
@@ -12995,6 +14131,44 @@
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
+			}
+		},
+		"react-addons-shallow-compare": {
+			"version": "15.6.3",
+			"resolved": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.3.tgz",
+			"integrity": "sha512-EDJbgKTtGRLhr3wiGDXK/+AEJ59yqGS+tKE6mue0aNXT6ZMR7VJbbzIiT6akotmHg1BLj46ElJSb+NBMp80XBg==",
+			"requires": {
+				"object-assign": "^4.1.0"
+			}
+		},
+		"react-autosize-textarea": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
+			"integrity": "sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g==",
+			"requires": {
+				"autosize": "^4.0.2",
+				"line-height": "^0.3.1",
+				"prop-types": "^15.5.6"
+			}
+		},
+		"react-dates": {
+			"version": "17.2.0",
+			"resolved": "https://registry.npmjs.org/react-dates/-/react-dates-17.2.0.tgz",
+			"integrity": "sha512-RDlerU8DdRRrlYS0MQ7Z9igPWABGLDwz6+ykBNff67RM3Sset2TDqeuOr+R5o00Ggn5U47GeLsGcSDxlZd9cHw==",
+			"requires": {
+				"airbnb-prop-types": "^2.10.0",
+				"consolidated-events": "^1.1.1 || ^2.0.0",
+				"is-touch-device": "^1.0.1",
+				"lodash": "^4.1.1",
+				"object.assign": "^4.1.0",
+				"object.values": "^1.0.4",
+				"prop-types": "^15.6.1",
+				"react-addons-shallow-compare": "^15.6.2",
+				"react-moment-proptypes": "^1.6.0",
+				"react-outside-click-handler": "^1.2.0",
+				"react-portal": "^4.1.5",
+				"react-with-styles": "^3.2.0",
+				"react-with-styles-interface-css": "^4.0.2"
 			}
 		},
 		"react-dom": {
@@ -13012,6 +14186,39 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
+		"react-moment-proptypes": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/react-moment-proptypes/-/react-moment-proptypes-1.8.1.tgz",
+			"integrity": "sha512-Er940DxWoObfIqPrZNfwXKugjxMIuk1LAuEzn23gytzV6hKS/sw108wibi9QubfMN4h+nrlje8eUCSbQRJo2fQ==",
+			"requires": {
+				"moment": ">=1.6.0"
+			}
+		},
+		"react-outside-click-handler": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.3.0.tgz",
+			"integrity": "sha512-Te/7zFU0oHpAnctl//pP3hEAeobfeHMyygHB8MnjP6sX5OR8KHT1G3jmLsV3U9RnIYo+Yn+peJYWu+D5tUS8qQ==",
+			"requires": {
+				"airbnb-prop-types": "^2.15.0",
+				"consolidated-events": "^1.1.1 || ^2.0.0",
+				"document.contains": "^1.0.1",
+				"object.values": "^1.1.0",
+				"prop-types": "^15.7.2"
+			}
+		},
+		"react-portal": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.1.tgz",
+			"integrity": "sha512-fE9kOBagwmTXZ3YGRYb4gcMy+kSA+yLO0xnPankjRlfBv4uCpFXqKPfkpsGQQR15wkZ9EssnvTOl1yMzbkxhPQ==",
+			"requires": {
+				"prop-types": "^15.5.8"
+			}
+		},
+		"react-resize-aware": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/react-resize-aware/-/react-resize-aware-3.1.1.tgz",
+			"integrity": "sha512-M8IyVLBN8D6tEUss+bxQlWte3ZYtNEGhg7rBxtCVG8yEBjUlZwUo5EFLq6tnvTZXcgAbCLjsQn+NCoTJKumRYg=="
+		},
 		"react-shallow-renderer": {
 			"version": "16.14.1",
 			"resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
@@ -13020,6 +14227,15 @@
 			"requires": {
 				"object-assign": "^4.1.1",
 				"react-is": "^16.12.0 || ^17.0.0"
+			}
+		},
+		"react-spring": {
+			"version": "8.0.27",
+			"resolved": "https://registry.npmjs.org/react-spring/-/react-spring-8.0.27.tgz",
+			"integrity": "sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==",
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"prop-types": "^15.5.8"
 			}
 		},
 		"react-test-renderer": {
@@ -13040,6 +14256,53 @@
 					"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
 					"dev": true
 				}
+			}
+		},
+		"react-use-gesture": {
+			"version": "9.1.3",
+			"resolved": "https://registry.npmjs.org/react-use-gesture/-/react-use-gesture-9.1.3.tgz",
+			"integrity": "sha512-CdqA2SmS/fj3kkS2W8ZU8wjTbVBAIwDWaRprX7OKaj7HlGwBasGEFggmk5qNklknqk9zK/h8D355bEJFTpqEMg=="
+		},
+		"react-with-direction": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/react-with-direction/-/react-with-direction-1.4.0.tgz",
+			"integrity": "sha512-ybHNPiAmaJpoWwugwqry9Hd1Irl2hnNXlo/2SXQBwbLn/jGMauMS2y9jw+ydyX5V9ICryCqObNSthNt5R94xpg==",
+			"requires": {
+				"airbnb-prop-types": "^2.16.0",
+				"brcast": "^2.0.2",
+				"deepmerge": "^1.5.2",
+				"direction": "^1.0.4",
+				"hoist-non-react-statics": "^3.3.2",
+				"object.assign": "^4.1.2",
+				"object.values": "^1.1.5",
+				"prop-types": "^15.7.2"
+			},
+			"dependencies": {
+				"deepmerge": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
+					"integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ=="
+				}
+			}
+		},
+		"react-with-styles": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-3.2.3.tgz",
+			"integrity": "sha512-MTI1UOvMHABRLj5M4WpODfwnveHaip6X7QUMI2x6zovinJiBXxzhA9AJP7MZNaKqg1JRFtHPXZdroUC8KcXwlQ==",
+			"requires": {
+				"hoist-non-react-statics": "^3.2.1",
+				"object.assign": "^4.1.0",
+				"prop-types": "^15.6.2",
+				"react-with-direction": "^1.3.0"
+			}
+		},
+		"react-with-styles-interface-css": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/react-with-styles-interface-css/-/react-with-styles-interface-css-4.0.3.tgz",
+			"integrity": "sha512-wE43PIyjal2dexxyyx4Lhbcb+E42amoYPnkunRZkb9WTA+Z+9LagbyxwsI352NqMdFmghR0opg29dzDO4/YXbw==",
+			"requires": {
+				"array.prototype.flat": "^1.2.1",
+				"global-cache": "^1.2.1"
 			}
 		},
 		"read-pkg": {
@@ -13178,6 +14441,39 @@
 				"picomatch": "^2.2.1"
 			}
 		},
+		"reakit": {
+			"version": "1.3.10",
+			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.10.tgz",
+			"integrity": "sha512-HxHtnegMDwidGU4Ik/fKTZ3coihf4nKeycs0QSIFWcau77qL5wL6xnqZrAxcjjDDPOIANct3LxTiAlf+qGLOlw==",
+			"requires": {
+				"@popperjs/core": "^2.5.4",
+				"body-scroll-lock": "^3.1.5",
+				"reakit-system": "^0.15.2",
+				"reakit-utils": "^0.15.2",
+				"reakit-warning": "^0.6.2"
+			}
+		},
+		"reakit-system": {
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.2.tgz",
+			"integrity": "sha512-TvRthEz0DmD0rcJkGamMYx+bATwnGNWJpe/lc8UV2Js8nnPvkaxrHk5fX9cVASFrWbaIyegZHCWUBfxr30bmmA==",
+			"requires": {
+				"reakit-utils": "^0.15.2"
+			}
+		},
+		"reakit-utils": {
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
+			"integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ=="
+		},
+		"reakit-warning": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.2.tgz",
+			"integrity": "sha512-z/3fvuc46DJyD3nJAUOto6inz2EbSQTjvI/KBQDqxwB0y02HDyeP8IWOJxvkuAUGkWpeSx+H3QWQFSNiPcHtmw==",
+			"requires": {
+				"reakit-utils": "^0.15.2"
+			}
+		},
 		"rechoir": {
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
@@ -13196,6 +14492,24 @@
 				"indent-string": "^4.0.0",
 				"strip-indent": "^3.0.0"
 			}
+		},
+		"redux": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-4.1.1.tgz",
+			"integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
+			"requires": {
+				"@babel/runtime": "^7.9.2"
+			}
+		},
+		"redux-multi": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/redux-multi/-/redux-multi-0.1.12.tgz",
+			"integrity": "sha1-KOH+XklnLLxb2KB/Cyrq8O+DVcI="
+		},
+		"reflect.ownkeys": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
+			"integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA="
 		},
 		"regenerate": {
 			"version": "1.4.2",
@@ -13324,6 +14638,11 @@
 				"mdast-util-to-markdown": "^0.6.0"
 			}
 		},
+		"rememo": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+			"integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
+		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -13351,8 +14670,7 @@
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-			"dev": true
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 		},
 		"require-from-string": {
 			"version": "2.0.2",
@@ -13363,8 +14681,7 @@
 		"require-main-filename": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-			"dev": true
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
 		},
 		"requireindex": {
 			"version": "1.2.0",
@@ -13499,6 +14816,11 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"rungen": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/rungen/-/rungen-0.3.2.tgz",
+			"integrity": "sha1-QAwJ6+kU57F+C27zJjQA/Cq8fLM="
+		},
 		"rxjs": {
 			"version": "6.6.7",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
@@ -13531,8 +14853,7 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sane": {
 			"version": "4.1.0",
@@ -13729,6 +15050,11 @@
 				"ajv-keywords": "^3.5.2"
 			}
 		},
+		"select": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+			"integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
+		},
 		"semver": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -13747,8 +15073,7 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
 		"set-value": {
 			"version": "2.0.1",
@@ -13824,11 +15149,18 @@
 			"dev": true,
 			"optional": true
 		},
+		"showdown": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
+			"integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
+			"requires": {
+				"yargs": "^14.2"
+			}
+		},
 		"side-channel": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
 			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.0",
 				"get-intrinsic": "^1.0.2",
@@ -13868,6 +15200,11 @@
 					"dev": true
 				}
 			}
+		},
+		"simple-html-tokenizer": {
+			"version": "0.5.11",
+			"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
+			"integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og=="
 		},
 		"sirv": {
 			"version": "1.0.17",
@@ -14259,7 +15596,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
 			"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3"
@@ -14269,7 +15605,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
 			"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3"
@@ -15842,6 +17177,14 @@
 				}
 			}
 		},
+		"tannin": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
+			"integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
+			"requires": {
+				"@tannin/plural-forms": "^1.1.0"
+			}
+		},
 		"tapable": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -16012,6 +17355,11 @@
 			"integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
 			"dev": true
 		},
+		"tiny-emitter": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+		},
 		"tiny-lr": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
@@ -16042,6 +17390,11 @@
 					"dev": true
 				}
 			}
+		},
+		"tinycolor2": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
+			"integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
 		},
 		"tmp": {
 			"version": "0.0.33",
@@ -16136,6 +17489,11 @@
 				"punycode": "^2.1.1"
 			}
 		},
+		"traverse": {
+			"version": "0.6.6",
+			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+			"integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+		},
 		"tree-kill": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -16213,6 +17571,11 @@
 				"tslib": "^1.8.1"
 			}
 		},
+		"turbo-combine-reducers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/turbo-combine-reducers/-/turbo-combine-reducers-1.0.2.tgz",
+			"integrity": "sha512-gHbdMZlA6Ym6Ur5pSH/UWrNQMIM9IqTH6SoL1DbHpqEdQ8i+cFunSmSlFykPt0eGQwZ4d/XTHOl74H0/kFBVWw=="
+		},
 		"type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -16259,7 +17622,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
 			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
 				"has-bigints": "^1.0.1",
@@ -16523,6 +17885,11 @@
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
 			"dev": true
 		},
+		"use-memo-one": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
+			"integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ=="
+		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -16544,9 +17911,7 @@
 		"uuid": {
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"dev": true,
-			"optional": true
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
 		},
 		"v8-compile-cache": {
 			"version": "2.3.0",
@@ -17120,7 +18485,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
 			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-			"dev": true,
 			"requires": {
 				"is-bigint": "^1.0.1",
 				"is-boolean-object": "^1.1.0",
@@ -17132,8 +18496,7 @@
 		"which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-			"dev": true
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 		},
 		"wildcard": {
 			"version": "2.0.0",
@@ -17151,7 +18514,6 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
 			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.0",
 				"string-width": "^3.0.0",
@@ -17161,14 +18523,12 @@
 				"ansi-regex": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -17177,7 +18537,6 @@
 					"version": "1.9.3",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
 					"requires": {
 						"color-name": "1.1.3"
 					}
@@ -17185,26 +18544,22 @@
 				"color-name": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
 				"emoji-regex": {
 					"version": "7.0.3",
 					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-					"dev": true
+					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 				},
 				"string-width": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
 					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
 					"requires": {
 						"emoji-regex": "^7.0.1",
 						"is-fullwidth-code-point": "^2.0.0",
@@ -17215,7 +18570,6 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
 					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^4.1.0"
 					}
@@ -17282,8 +18636,7 @@
 		"y18n": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-			"dev": true
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
 		},
 		"yallist": {
 			"version": "4.0.0",
@@ -17300,7 +18653,6 @@
 			"version": "14.2.3",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
 			"integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-			"dev": true,
 			"requires": {
 				"cliui": "^5.0.0",
 				"decamelize": "^1.2.0",
@@ -17318,26 +18670,22 @@
 				"ansi-regex": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
 				},
 				"emoji-regex": {
 					"version": "7.0.3",
 					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-					"dev": true
+					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 				},
 				"string-width": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
 					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
 					"requires": {
 						"emoji-regex": "^7.0.1",
 						"is-fullwidth-code-point": "^2.0.0",
@@ -17348,7 +18696,6 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
 					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^4.1.0"
 					}
@@ -17359,7 +18706,6 @@
 			"version": "15.0.3",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.3.tgz",
 			"integrity": "sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==",
-			"dev": true,
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2513,42 +2513,6 @@
 				"slash": "^3.0.0"
 			}
 		},
-		"@jest/core": {
-			"version": "26.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.3.tgz",
-			"integrity": "sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==",
-			"dev": true,
-			"requires": {
-				"@jest/console": "^26.6.2",
-				"@jest/reporters": "^26.6.2",
-				"@jest/test-result": "^26.6.2",
-				"@jest/transform": "^26.6.2",
-				"@jest/types": "^26.6.2",
-				"@types/node": "*",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.0.0",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.4",
-				"jest-changed-files": "^26.6.2",
-				"jest-config": "^26.6.3",
-				"jest-haste-map": "^26.6.2",
-				"jest-message-util": "^26.6.2",
-				"jest-regex-util": "^26.0.0",
-				"jest-resolve": "^26.6.2",
-				"jest-resolve-dependencies": "^26.6.3",
-				"jest-runner": "^26.6.3",
-				"jest-runtime": "^26.6.3",
-				"jest-snapshot": "^26.6.2",
-				"jest-util": "^26.6.2",
-				"jest-validate": "^26.6.2",
-				"jest-watcher": "^26.6.2",
-				"micromatch": "^4.0.2",
-				"p-each-series": "^2.1.0",
-				"rimraf": "^3.0.0",
-				"slash": "^3.0.0",
-				"strip-ansi": "^6.0.0"
-			}
-		},
 		"@jest/environment": {
 			"version": "26.6.2",
 			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.2.tgz",
@@ -2584,47 +2548,6 @@
 				"@jest/environment": "^26.6.2",
 				"@jest/types": "^26.6.2",
 				"expect": "^26.6.2"
-			}
-		},
-		"@jest/reporters": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.2.tgz",
-			"integrity": "sha512-h2bW53APG4HvkOnVMo8q3QXa6pcaNt1HkwVsOPMBV6LD/q9oSpxNSYZQYkAnjdMjrJ86UuYeLo+aEZClV6opnw==",
-			"dev": true,
-			"requires": {
-				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "^26.6.2",
-				"@jest/test-result": "^26.6.2",
-				"@jest/transform": "^26.6.2",
-				"@jest/types": "^26.6.2",
-				"chalk": "^4.0.0",
-				"collect-v8-coverage": "^1.0.0",
-				"exit": "^0.1.2",
-				"glob": "^7.1.2",
-				"graceful-fs": "^4.2.4",
-				"istanbul-lib-coverage": "^3.0.0",
-				"istanbul-lib-instrument": "^4.0.3",
-				"istanbul-lib-report": "^3.0.0",
-				"istanbul-lib-source-maps": "^4.0.0",
-				"istanbul-reports": "^3.0.2",
-				"jest-haste-map": "^26.6.2",
-				"jest-resolve": "^26.6.2",
-				"jest-util": "^26.6.2",
-				"jest-worker": "^26.6.2",
-				"node-notifier": "^8.0.0",
-				"slash": "^3.0.0",
-				"source-map": "^0.6.0",
-				"string-length": "^4.0.1",
-				"terminal-link": "^2.0.0",
-				"v8-to-istanbul": "^7.0.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
 			}
 		},
 		"@jest/source-map": {
@@ -4959,6 +4882,339 @@
 				"webpack-bundle-analyzer": "^4.4.2",
 				"webpack-cli": "^4.7.2",
 				"webpack-livereload-plugin": "^3.0.1"
+			},
+			"dependencies": {
+				"@jest/core": {
+					"version": "26.6.3",
+					"resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.3.tgz",
+					"integrity": "sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^26.6.2",
+						"@jest/reporters": "^26.6.2",
+						"@jest/test-result": "^26.6.2",
+						"@jest/transform": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"@types/node": "*",
+						"ansi-escapes": "^4.2.1",
+						"chalk": "^4.0.0",
+						"exit": "^0.1.2",
+						"graceful-fs": "^4.2.4",
+						"jest-changed-files": "^26.6.2",
+						"jest-config": "^26.6.3",
+						"jest-haste-map": "^26.6.2",
+						"jest-message-util": "^26.6.2",
+						"jest-regex-util": "^26.0.0",
+						"jest-resolve": "^26.6.2",
+						"jest-resolve-dependencies": "^26.6.3",
+						"jest-runner": "^26.6.3",
+						"jest-runtime": "^26.6.3",
+						"jest-snapshot": "^26.6.2",
+						"jest-util": "^26.6.2",
+						"jest-validate": "^26.6.2",
+						"jest-watcher": "^26.6.2",
+						"micromatch": "^4.0.2",
+						"p-each-series": "^2.1.0",
+						"rimraf": "^3.0.0",
+						"slash": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"@jest/reporters": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.2.tgz",
+					"integrity": "sha512-h2bW53APG4HvkOnVMo8q3QXa6pcaNt1HkwVsOPMBV6LD/q9oSpxNSYZQYkAnjdMjrJ86UuYeLo+aEZClV6opnw==",
+					"dev": true,
+					"requires": {
+						"@bcoe/v8-coverage": "^0.2.3",
+						"@jest/console": "^26.6.2",
+						"@jest/test-result": "^26.6.2",
+						"@jest/transform": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"chalk": "^4.0.0",
+						"collect-v8-coverage": "^1.0.0",
+						"exit": "^0.1.2",
+						"glob": "^7.1.2",
+						"graceful-fs": "^4.2.4",
+						"istanbul-lib-coverage": "^3.0.0",
+						"istanbul-lib-instrument": "^4.0.3",
+						"istanbul-lib-report": "^3.0.0",
+						"istanbul-lib-source-maps": "^4.0.0",
+						"istanbul-reports": "^3.0.2",
+						"jest-haste-map": "^26.6.2",
+						"jest-resolve": "^26.6.2",
+						"jest-util": "^26.6.2",
+						"jest-worker": "^26.6.2",
+						"node-notifier": "^8.0.0",
+						"slash": "^3.0.0",
+						"source-map": "^0.6.0",
+						"string-length": "^4.0.1",
+						"terminal-link": "^2.0.0",
+						"v8-to-istanbul": "^7.0.0"
+					}
+				},
+				"cliui": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^6.2.0"
+					}
+				},
+				"execa": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+					"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^7.0.0",
+						"get-stream": "^5.0.0",
+						"human-signals": "^1.1.1",
+						"is-stream": "^2.0.0",
+						"merge-stream": "^2.0.0",
+						"npm-run-path": "^4.0.0",
+						"onetime": "^5.1.0",
+						"signal-exit": "^3.0.2",
+						"strip-final-newline": "^2.0.0"
+					},
+					"dependencies": {
+						"cross-spawn": {
+							"version": "7.0.3",
+							"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+							"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+							"dev": true,
+							"requires": {
+								"path-key": "^3.1.0",
+								"shebang-command": "^2.0.0",
+								"which": "^2.0.1"
+							}
+						}
+					}
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"human-signals": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+					"integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+					"dev": true
+				},
+				"is-stream": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+					"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+					"dev": true
+				},
+				"jest": {
+					"version": "26.6.3",
+					"resolved": "https://registry.npmjs.org/jest/-/jest-26.6.3.tgz",
+					"integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
+					"dev": true,
+					"requires": {
+						"@jest/core": "^26.6.3",
+						"import-local": "^3.0.2",
+						"jest-cli": "^26.6.3"
+					},
+					"dependencies": {
+						"jest-cli": {
+							"version": "26.6.3",
+							"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
+							"integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
+							"dev": true,
+							"requires": {
+								"@jest/core": "^26.6.3",
+								"@jest/test-result": "^26.6.2",
+								"@jest/types": "^26.6.2",
+								"chalk": "^4.0.0",
+								"exit": "^0.1.2",
+								"graceful-fs": "^4.2.4",
+								"import-local": "^3.0.2",
+								"is-ci": "^2.0.0",
+								"jest-config": "^26.6.3",
+								"jest-util": "^26.6.2",
+								"jest-validate": "^26.6.2",
+								"prompts": "^2.0.1",
+								"yargs": "^15.4.1"
+							}
+						}
+					}
+				},
+				"jest-changed-files": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.2.tgz",
+					"integrity": "sha512-fDS7szLcY9sCtIip8Fjry9oGf3I2ht/QT21bAHm5Dmf0mD4X3ReNUf17y+bO6fR8WgbIZTlbyG1ak/53cbRzKQ==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^26.6.2",
+						"execa": "^4.0.0",
+						"throat": "^5.0.0"
+					}
+				},
+				"jest-resolve-dependencies": {
+					"version": "26.6.3",
+					"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3.tgz",
+					"integrity": "sha512-pVwUjJkxbhe4RY8QEWzN3vns2kqyuldKpxlxJlzEYfKSvY6/bMvxoFrYYzUO1Gx28yKWN37qyV7rIoIp2h8fTg==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^26.6.2",
+						"jest-regex-util": "^26.0.0",
+						"jest-snapshot": "^26.6.2"
+					}
+				},
+				"jest-watcher": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.2.tgz",
+					"integrity": "sha512-WKJob0P/Em2csiVthsI68p6aGKTIcsfjH9Gsx1f0A3Italz43e3ho0geSAVsmj09RWOELP1AZ/DXyJgOgDKxXQ==",
+					"dev": true,
+					"requires": {
+						"@jest/test-result": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"@types/node": "*",
+						"ansi-escapes": "^4.2.1",
+						"chalk": "^4.0.0",
+						"jest-util": "^26.6.2",
+						"string-length": "^4.0.1"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"npm-run-path": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"v8-to-istanbul": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.1.2.tgz",
+					"integrity": "sha512-TxNb7YEUwkLXCQYeudi6lgQ/SZrzNO4kMdlqVxaZPUIUjCv6iSSypUQX70kNBSERpQ8fk48+d61FXk+tgqcWow==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.1",
+						"convert-source-map": "^1.6.0",
+						"source-map": "^0.7.3"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.7.3",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+							"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+							"dev": true
+						}
+					}
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"yargs": {
+					"version": "15.4.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+					"dev": true,
+					"requires": {
+						"cliui": "^6.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^4.1.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^4.2.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^18.1.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
 			}
 		},
 		"@wordpress/shortcode": {
@@ -9295,12 +9551,6 @@
 				}
 			}
 		},
-		"human-signals": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-			"integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-			"dev": true
-		},
 		"iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -9983,211 +10233,6 @@
 				"istanbul-lib-report": "^3.0.0"
 			}
 		},
-		"jest": {
-			"version": "26.6.3",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-26.6.3.tgz",
-			"integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
-			"dev": true,
-			"requires": {
-				"@jest/core": "^26.6.3",
-				"import-local": "^3.0.2",
-				"jest-cli": "^26.6.3"
-			},
-			"dependencies": {
-				"cliui": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-					"dev": true,
-					"requires": {
-						"string-width": "^4.2.0",
-						"strip-ansi": "^6.0.0",
-						"wrap-ansi": "^6.2.0"
-					}
-				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"jest-cli": {
-					"version": "26.6.3",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
-					"integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
-					"dev": true,
-					"requires": {
-						"@jest/core": "^26.6.3",
-						"@jest/test-result": "^26.6.2",
-						"@jest/types": "^26.6.2",
-						"chalk": "^4.0.0",
-						"exit": "^0.1.2",
-						"graceful-fs": "^4.2.4",
-						"import-local": "^3.0.2",
-						"is-ci": "^2.0.0",
-						"jest-config": "^26.6.3",
-						"jest-util": "^26.6.2",
-						"jest-validate": "^26.6.2",
-						"prompts": "^2.0.1",
-						"yargs": "^15.4.1"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"wrap-ansi": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"yargs": {
-					"version": "15.4.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-					"dev": true,
-					"requires": {
-						"cliui": "^6.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^4.1.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^4.2.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^18.1.2"
-					}
-				},
-				"yargs-parser": {
-					"version": "18.1.3",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
-			}
-		},
-		"jest-changed-files": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.2.tgz",
-			"integrity": "sha512-fDS7szLcY9sCtIip8Fjry9oGf3I2ht/QT21bAHm5Dmf0mD4X3ReNUf17y+bO6fR8WgbIZTlbyG1ak/53cbRzKQ==",
-			"dev": true,
-			"requires": {
-				"@jest/types": "^26.6.2",
-				"execa": "^4.0.0",
-				"throat": "^5.0.0"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-					"dev": true,
-					"requires": {
-						"path-key": "^3.1.0",
-						"shebang-command": "^2.0.0",
-						"which": "^2.0.1"
-					}
-				},
-				"execa": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-					"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^7.0.0",
-						"get-stream": "^5.0.0",
-						"human-signals": "^1.1.1",
-						"is-stream": "^2.0.0",
-						"merge-stream": "^2.0.0",
-						"npm-run-path": "^4.0.0",
-						"onetime": "^5.1.0",
-						"signal-exit": "^3.0.2",
-						"strip-final-newline": "^2.0.0"
-					}
-				},
-				"is-stream": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-					"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-					"dev": true
-				},
-				"npm-run-path": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-					"dev": true,
-					"requires": {
-						"path-key": "^3.0.0"
-					}
-				},
-				"path-key": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-					"dev": true
-				},
-				"shebang-command": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-					"dev": true,
-					"requires": {
-						"shebang-regex": "^3.0.0"
-					}
-				},
-				"shebang-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-					"dev": true
-				},
-				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				}
-			}
-		},
 		"jest-circus": {
 			"version": "26.6.3",
 			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-26.6.3.tgz",
@@ -10525,17 +10570,6 @@
 				}
 			}
 		},
-		"jest-resolve-dependencies": {
-			"version": "26.6.3",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3.tgz",
-			"integrity": "sha512-pVwUjJkxbhe4RY8QEWzN3vns2kqyuldKpxlxJlzEYfKSvY6/bMvxoFrYYzUO1Gx28yKWN37qyV7rIoIp2h8fTg==",
-			"dev": true,
-			"requires": {
-				"@jest/types": "^26.6.2",
-				"jest-regex-util": "^26.0.0",
-				"jest-snapshot": "^26.6.2"
-			}
-		},
 		"jest-runner": {
 			"version": "26.6.3",
 			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.3.tgz",
@@ -10771,21 +10805,6 @@
 					"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
 					"dev": true
 				}
-			}
-		},
-		"jest-watcher": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.2.tgz",
-			"integrity": "sha512-WKJob0P/Em2csiVthsI68p6aGKTIcsfjH9Gsx1f0A3Italz43e3ho0geSAVsmj09RWOELP1AZ/DXyJgOgDKxXQ==",
-			"dev": true,
-			"requires": {
-				"@jest/test-result": "^26.6.2",
-				"@jest/types": "^26.6.2",
-				"@types/node": "*",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.0.0",
-				"jest-util": "^26.6.2",
-				"string-length": "^4.0.1"
 			}
 		},
 		"jest-worker": {
@@ -17918,25 +17937,6 @@
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
-		},
-		"v8-to-istanbul": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.1.2.tgz",
-			"integrity": "sha512-TxNb7YEUwkLXCQYeudi6lgQ/SZrzNO4kMdlqVxaZPUIUjCv6iSSypUQX70kNBSERpQ8fk48+d61FXk+tgqcWow==",
-			"dev": true,
-			"requires": {
-				"@types/istanbul-lib-coverage": "^2.0.1",
-				"convert-source-map": "^1.6.0",
-				"source-map": "^0.7.3"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.7.3",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-					"dev": true
-				}
-			}
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
 	},
 	"devDependencies": {
 		"@types/jest": "^27.0.2",
+		"@types/wordpress__block-editor": "^6.0.4",
+		"@types/wordpress__blocks": "^9.1.1",
+		"@types/wordpress__data": "^4.6.10",
 		"@wordpress/env": "^4.1.2",
 		"@wordpress/scripts": "^18.1.0",
 		"opener": "^1.5.2",
@@ -26,6 +29,15 @@
 	"dependencies": {
 		"@emotion/react": "^11.4.1",
 		"@emotion/styled": "^11.3.0",
-		"@wordpress/icons": "^6.0.0"
+		"@wordpress/api-fetch": "^5.1.2",
+		"@wordpress/block-editor": "^6.1.14",
+		"@wordpress/blocks": "^9.1.8",
+		"@wordpress/components": "^14.1.11",
+		"@wordpress/compose": "^4.1.6",
+		"@wordpress/core-data": "^3.1.12",
+		"@wordpress/data": "^5.1.6",
+		"@wordpress/hooks": "^3.2.1",
+		"@wordpress/i18n": "^4.1.2",
+		"@wordpress/icons": "^4.0.3"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,9 @@
 		"resolveJsonModule": true,
 
 		"typeRoots": [ "./node_modules/@types" ],
-		"types": []
+		"types": [
+			"@types/jest"
+		]
 	},
 	"include": [
 		"**/*.ts", "**/*.tsx","**/*.js", "**/*.jsx","**/*.ts", "**/*.json"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,42 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": false,
+		"allowSyntheticDefaultImports": true,
+		"jsx": "preserve",
+		"target": "esnext",
+		"module": "esnext",
+		"lib": [ "dom", "esnext" ],
+		"declaration": true,
+		"declarationMap": true,
+		"composite": true,
+		"emitDeclarationOnly": true,
+		"isolatedModules": true,
+
+		/* Strict Type-Checking Options */
+		"strict": true,
+
+		/* Additional Checks */
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"importsNotUsedAsValues": "error",
+
+		/* Module Resolution Options */
+		"moduleResolution": "node",
+		/* This needs to be false so our types are possible to consume without setting this */
+		"esModuleInterop": false,
+		"resolveJsonModule": true,
+
+		"typeRoots": [ "./node_modules/@types" ],
+		"types": []
+	},
+	"include": [
+		"**/*.ts", "**/*.tsx","**/*.js", "**/*.jsx","**/*.ts", "**/*.json"
+	],
+	"exclude": [
+		"**/build/**",
+		"**/test/**",
+	]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,4 +6,20 @@ module.exports = {
 		maxEntrypointSize: 1000000,
 		maxAssetSize: 1000000,
 	},
+	resolve: {
+		...defaultConfig.resolve,
+		extensions: [ '.ts', '.tsx', '.js' ],
+	},
+	module: {
+		...defaultConfig.module,
+		rules: defaultConfig.module.rules.map( ( rule ) => {
+			if ( rule.test.toString() === /\.jsx?$/.toString() ) {
+				return {
+					...rule,
+					test: /\.(js|jsx|ts|tsx)$/,
+				};
+			}
+			return rule;
+		} ),
+	},
 };


### PR DESCRIPTION
* Typescript を用いてコードが書けるように設定変更。
* `@wordpress` 系のパッケージを npm の依存関係に追加。バージョンは、WordPress 5.8 に合わせる。
