### PR TITLE
Revert focus-first-cell behavior on row/column insert and delete

### DIFF
--- a/src/elements/table.tsx
+++ b/src/elements/table.tsx
@@ -194,20 +194,6 @@ export default function Table( {
 		}
 	};
 
-	const focusFirstCell = () => {
-		if ( ! tableRef.current ) {
-			return;
-		}
-		const tableElement: HTMLTableElement = tableRef.current;
-		const firstTabbableElement = tableElement.querySelector(
-			`th > [contenteditable="true"], td > [contenteditable="true"]`
-		);
-		if ( ! firstTabbableElement ) {
-			return;
-		}
-		( firstTabbableElement as HTMLElement ).focus();
-	};
-
 	const onChangeCellContent = ( content: string, targetCell: VCell ) => {
 		// If inline highlight is applied to the RichText, this process is performed before rendering the component, causing a warning error.
 		// Therefore, nothing is performed if the component has not yet been rendered.
@@ -505,7 +491,6 @@ export default function Table( {
 														iconSize={ 18 }
 														onClick={ ( event: MouseEvent ) => {
 															onInsertRow( sectionName, rowIndex );
-															focusFirstCell();
 															event.stopPropagation();
 														} }
 													/>
@@ -541,7 +526,6 @@ export default function Table( {
 																	icon={ trash }
 																	onClick={ ( event: MouseEvent ) => {
 																		onDeleteRow( sectionName, rowIndex );
-																		focusFirstCell();
 																		event.stopPropagation();
 																	} }
 																/>
@@ -557,7 +541,6 @@ export default function Table( {
 														iconSize={ 18 }
 														onClick={ ( event: MouseEvent ) => {
 															onInsertColumn( cell, 0 );
-															focusFirstCell();
 															event.stopPropagation();
 														} }
 													/>
@@ -589,7 +572,6 @@ export default function Table( {
 																icon={ trash }
 																onClick={ ( event: MouseEvent ) => {
 																	onDeleteColumn( vColIndex );
-																	focusFirstCell();
 																	event.stopPropagation();
 																} }
 															/>
@@ -609,7 +591,6 @@ export default function Table( {
 														iconSize={ 18 }
 														onClick={ ( event: MouseEvent ) => {
 															onInsertRow( sectionName, rowIndex + rowSpan );
-															focusFirstCell();
 															event.stopPropagation();
 														} }
 													/>
@@ -642,7 +623,6 @@ export default function Table( {
 													iconSize={ 18 }
 													onClick={ ( event: MouseEvent ) => {
 														onInsertColumn( cell, 1 );
-														focusFirstCell();
 														event.stopPropagation();
 													} }
 												/>

--- a/test/e2e/specs/table.spec.ts
+++ b/test/e2e/specs/table.spec.ts
@@ -130,9 +130,6 @@ test.describe( 'Flexible table', () => {
 			await page.getByRole( 'menuitem', { name: 'Merge cells' } ).click();
 			await editor.canvas.getByRole( 'button', { name: 'Select row' } ).nth( 2 ).click();
 			await editor.canvas.getByRole( 'button', { name: 'Delete row' } ).click();
-			await expect(
-				editor.canvas.getByRole( 'textbox', { name: 'Body cell text' } ).nth( 0 )
-			).toBeFocused();
 			expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 		} );
 
@@ -150,9 +147,6 @@ test.describe( 'Flexible table', () => {
 			await page.getByRole( 'menuitem', { name: 'Merge cells' } ).click();
 			await editor.canvas.getByRole( 'button', { name: 'Select column' } ).nth( 2 ).click();
 			await editor.canvas.getByRole( 'button', { name: 'Delete column' } ).click();
-			await expect(
-				editor.canvas.getByRole( 'textbox', { name: 'Body cell text' } ).nth( 0 )
-			).toBeFocused();
 			expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 		} );
 


### PR DESCRIPTION
Moving focus to the first cell after inserting or deleting a row or column is disruptive on long tables, where it yanks focus far away from where the user was working. Focus management for the inline control buttons needs to be reconsidered holistically (including the focus_control_button option and screen reader behavior), so revert this behavior for now and remove the related e2e focus assertions.