### PR TITLE
Use manage_options capability for global setting access

### DIFF
--- a/classes/class-api.php
+++ b/classes/class-api.php
@@ -45,7 +45,7 @@ class Api {
 						if ( $show_global_setting ) {
 							return current_user_can( 'edit_posts' );
 						} else {
-							return current_user_can( 'administrator' );
+							return current_user_can( 'manage_options' );
 						}
 					},
 				),
@@ -58,7 +58,7 @@ class Api {
 						if ( $show_global_setting ) {
 							return current_user_can( 'edit_posts' );
 						} else {
-							return current_user_can( 'administrator' );
+							return current_user_can( 'manage_options' );
 						}
 					},
 				),

--- a/src/settings/global-settings/index.tsx
+++ b/src/settings/global-settings/index.tsx
@@ -18,22 +18,28 @@ import SettingModal from './setting-modal';
 import type { StoreOptions } from '../../store';
 
 export default function GlobalSettings() {
-	const { options, isAdministrator, hasResolved } = useSelect( ( select ) => {
+	const { options, canManageOptions, hasResolved } = useSelect( ( select ) => {
 		return {
 			// @ts-ignore
 			options: select( STORE_NAME ).getOptions() as StoreOptions,
-			isAdministrator: !! select( coreStore ).canUser( 'create', 'users' ),
+			canManageOptions: !! select( coreStore ).canUser( 'update', {
+				kind: 'root',
+				name: 'site',
+			} ),
 			hasResolved:
 				// @ts-ignore
 				select( STORE_NAME ).hasFinishedResolution( 'getOptions' ) &&
-				select( coreStore ).hasFinishedResolution( 'canUser', [ 'create', 'users' ] ),
+				select( coreStore ).hasFinishedResolution( 'canUser', [
+					'update',
+					{ kind: 'root', name: 'site' },
+				] ),
 		};
 	}, [] );
 
 	const [ isSettingModalOpen, setIsSettingModalOpen ] = useState( false );
 	const [ isHelpModalOpen, setIsHelpModalOpen ] = useState( false );
 
-	const showGlobalSetting = isAdministrator || options?.show_global_setting;
+	const showGlobalSetting = canManageOptions || options?.show_global_setting;
 
 	return (
 		<>
@@ -53,11 +59,11 @@ export default function GlobalSettings() {
 				/>
 			</HStack>
 			{ isHelpModalOpen && <HelpModal { ...{ setIsHelpModalOpen } } /> }
-			{ options && isSettingModalOpen && ( isAdministrator || options?.show_global_setting ) && (
+			{ options && isSettingModalOpen && ( canManageOptions || options?.show_global_setting ) && (
 				<SettingModal
 					{ ...{
 						options,
-						isAdministrator,
+						canManageOptions,
 						setIsSettingModalOpen,
 					} }
 				/>

--- a/src/settings/global-settings/index.tsx
+++ b/src/settings/global-settings/index.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 // @ts-ignore: has no exported member
 import { store as coreStore } from '@wordpress/core-data';
@@ -18,36 +18,28 @@ import SettingModal from './setting-modal';
 import type { StoreOptions } from '../../store';
 
 export default function GlobalSettings() {
-	const storeOptions: StoreOptions = useSelect(
-		( select ) =>
-			select( STORE_NAME )
+	const { options, isAdministrator, hasResolved } = useSelect( ( select ) => {
+		return {
+			// @ts-ignore
+			options: select( STORE_NAME ).getOptions() as StoreOptions,
+			isAdministrator: !! select( coreStore ).canUser( 'create', 'users' ),
+			hasResolved:
 				// @ts-ignore
-				.getOptions(),
-		[]
-	);
-
-	const isAdministrator = useSelect(
-		( select ) => !! select( coreStore ).canUser( 'create', 'users' ),
-		[]
-	);
+				select( STORE_NAME ).hasFinishedResolution( 'getOptions' ) &&
+				select( coreStore ).hasFinishedResolution( 'canUser', [ 'create', 'users' ] ),
+		};
+	}, [] );
 
 	const [ isSettingModalOpen, setIsSettingModalOpen ] = useState( false );
 	const [ isHelpModalOpen, setIsHelpModalOpen ] = useState( false );
-	const [ options, setOptions ] = useState< StoreOptions >();
 
-	// Set options to state.
-	useEffect( () => {
-		setOptions( storeOptions );
-	}, [ storeOptions ] );
-
-	const isGlobalSettingLoaded = isAdministrator !== undefined && options !== undefined;
 	const showGlobalSetting = isAdministrator || options?.show_global_setting;
 
 	return (
 		<>
 			<HStack>
-				{ ! isGlobalSettingLoaded && <Spinner /> }
-				{ isGlobalSettingLoaded && showGlobalSetting && (
+				{ ! hasResolved && <Spinner /> }
+				{ hasResolved && showGlobalSetting && (
 					<Button variant="primary" onClick={ () => setIsSettingModalOpen( true ) } size="compact">
 						{ __( 'Edit global setting', 'flexible-table-block' ) }
 					</Button>

--- a/src/settings/global-settings/setting-modal.tsx
+++ b/src/settings/global-settings/setting-modal.tsx
@@ -58,7 +58,7 @@ import type { ApiResponse, StoreOptions } from '../../store';
 
 type Props = {
 	options: StoreOptions;
-	isAdministrator: boolean;
+	canManageOptions: boolean;
 	setIsSettingModalOpen: Dispatch< SetStateAction< boolean > >;
 };
 
@@ -69,7 +69,11 @@ interface NoticeInfo {
 	message?: string;
 }
 
-export default function SettingModal( { options, isAdministrator, setIsSettingModalOpen }: Props ) {
+export default function SettingModal( {
+	options,
+	canManageOptions,
+	setIsSettingModalOpen,
+}: Props ) {
 	const [ noticeInfo, setNoticeInfo ] = useState< NoticeInfo | undefined >( undefined );
 	const [ isResetPopup, setIsResetPopup ] = useState( false );
 	const [ isWaiting, setIsWaiting ] = useState( false );
@@ -767,7 +771,7 @@ export default function SettingModal( { options, isAdministrator, setIsSettingMo
 									} }
 									__nextHasNoMarginBottom
 								/>
-								{ isAdministrator && (
+								{ canManageOptions && (
 									<ToggleControl
 										label={ __(
 											'Show Global setting button to non-administrative users',


### PR DESCRIPTION
## What & Why

The global setting access check relied on `canUser( 'create', 'users' )`, a proxy that does not match the capability the feature actually needs. This fixes the gate to use `manage_options` consistently on both the client and the server.

## Changes

- Switch the client capability check to `canUser( 'update', { kind: 'root', name: 'site' } )` (`manage_options`) and rename `isAdministrator` to `canManageOptions`.
- Change the REST write permission callbacks from the `administrator` role to `current_user_can( 'manage_options' )`, so the client- and server-side gates agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
