### PR TITLE
Restrict global setting reset to manage_options users

### DIFF
--- a/classes/class-api.php
+++ b/classes/class-api.php
@@ -53,13 +53,7 @@ class Api {
 					'methods'             => 'DELETE',
 					'callback'            => array( $this, 'delete_options' ),
 					'permission_callback' => function () {
-						$show_global_setting = get_option( Option::OPTION_NAMES['show_global_setting'], Settings::OPTIONS['show_global_setting']['default'] );
-
-						if ( $show_global_setting ) {
-							return current_user_can( 'edit_posts' );
-						} else {
-							return current_user_can( 'manage_options' );
-						}
+						return current_user_can( 'manage_options' );
 					},
 				),
 			)

--- a/src/settings/global-settings/setting-modal.tsx
+++ b/src/settings/global-settings/setting-modal.tsx
@@ -822,38 +822,40 @@ export default function SettingModal( {
 				>
 					{ __( 'Save settings', 'flexible-table-block' ) }
 				</Button>
-				<Button
-					isDestructive
-					disabled={ isWaiting }
-					onClick={ () => setIsResetPopup( ! isResetPopup ) }
-					__next40pxDefaultSize
-				>
-					{ __( 'Restore default settings', 'flexible-table-block' ) }
-					{ isResetPopup && (
-						<Popover
-							className="ftb-global-setting-modal__confirm-popover"
-							focusOnMount="firstElement"
-							placement="top"
-							onClose={ () => setIsResetPopup( false ) }
-						>
-							<Spacer as={ VStack } marginBottom={ 0 } padding={ 2 } spacing={ 4 }>
-								<Text as="p">{ __( 'Are you sure?', 'flexible-table-block' ) }</Text>
-								<HStack>
-									<Button isDestructive onClick={ handleResetOptions } size="compact">
-										{ __( 'Restore', 'flexible-table-block' ) }
-									</Button>
-									<Button
-										variant="secondary"
-										onClick={ () => setIsResetPopup( false ) }
-										size="compact"
-									>
-										{ __( 'Cancel', 'flexible-table-block' ) }
-									</Button>
-								</HStack>
-							</Spacer>
-						</Popover>
-					) }
-				</Button>
+				{ canManageOptions && (
+					<Button
+						isDestructive
+						disabled={ isWaiting }
+						onClick={ () => setIsResetPopup( ! isResetPopup ) }
+						__next40pxDefaultSize
+					>
+						{ __( 'Restore default settings', 'flexible-table-block' ) }
+						{ isResetPopup && (
+							<Popover
+								className="ftb-global-setting-modal__confirm-popover"
+								focusOnMount="firstElement"
+								placement="top"
+								onClose={ () => setIsResetPopup( false ) }
+							>
+								<Spacer as={ VStack } marginBottom={ 0 } padding={ 2 } spacing={ 4 }>
+									<Text as="p">{ __( 'Are you sure?', 'flexible-table-block' ) }</Text>
+									<HStack>
+										<Button isDestructive onClick={ handleResetOptions } size="compact">
+											{ __( 'Restore', 'flexible-table-block' ) }
+										</Button>
+										<Button
+											variant="secondary"
+											onClick={ () => setIsResetPopup( false ) }
+											size="compact"
+										>
+											{ __( 'Cancel', 'flexible-table-block' ) }
+										</Button>
+									</HStack>
+								</Spacer>
+							</Popover>
+						) }
+					</Button>
+				) }
 			</Spacer>
 		</Modal>
 	);


### PR DESCRIPTION
## What & Why

A non-administrative user could reset the global settings, which restored `show_global_setting` to its default of `false`. That immediately revoked their own access and closed the modal. Resetting is destructive and should be limited to users who can manage options.

## Changes

- Hide the "Restore default settings" button unless the user has `manage_options`.
- Tighten the DELETE REST permission callback to require `manage_options` regardless of `show_global_setting`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
