### PR TITLE
Remove __nextHasNoMarginBottom prop from controls

### DIFF
--- a/src/controls/border-color-control.tsx
+++ b/src/controls/border-color-control.tsx
@@ -119,11 +119,7 @@ export default function BorderColorControl( {
 	};
 
 	return (
-		<BaseControl
-			className={ clsx( 'ftb-border-color-control', className ) }
-			help={ help }
-			__nextHasNoMarginBottom
-		>
+		<BaseControl className={ clsx( 'ftb-border-color-control', className ) } help={ help }>
 			<VStack aria-labelledby={ headingId } role="group">
 				<Text id={ headingId } upperCase size="11" weight="500">
 					{ label }

--- a/src/controls/border-radius-control.tsx
+++ b/src/controls/border-radius-control.tsx
@@ -135,11 +135,7 @@ export default function BorderRadiusControl( {
 	};
 
 	return (
-		<BaseControl
-			className={ clsx( 'ftb-border-radius-control', className ) }
-			help={ help }
-			__nextHasNoMarginBottom
-		>
+		<BaseControl className={ clsx( 'ftb-border-radius-control', className ) } help={ help }>
 			<VStack aria-labelledby={ headingId } role="group">
 				<Text id={ headingId } upperCase size="11" weight="500">
 					{ label }

--- a/src/controls/border-spacing-control.tsx
+++ b/src/controls/border-spacing-control.tsx
@@ -107,7 +107,7 @@ export default function BorderSpacingControl( {
 	};
 
 	return (
-		<BaseControl className="ftb-border-spacing-control" help={ help } __nextHasNoMarginBottom>
+		<BaseControl className="ftb-border-spacing-control" help={ help }>
 			<VStack aria-labelledby={ headingId } role="group">
 				<Text id={ headingId } upperCase size="11" weight="500">
 					{ label }

--- a/src/controls/border-style-control.tsx
+++ b/src/controls/border-style-control.tsx
@@ -111,11 +111,7 @@ export default function BorderStyleControl( {
 	};
 
 	return (
-		<BaseControl
-			className={ clsx( 'ftb-border-style-control', className ) }
-			help={ help }
-			__nextHasNoMarginBottom
-		>
+		<BaseControl className={ clsx( 'ftb-border-style-control', className ) } help={ help }>
 			<VStack aria-labelledby={ headingId } role="group">
 				<Text id={ headingId } upperCase size="11" weight="500">
 					{ isMixed && isLinked
@@ -128,7 +124,6 @@ export default function BorderStyleControl( {
 							{ hasIndicator && <SideIndicatorControl /> }
 							<ToggleGroupControl
 								hideLabelFromVision
-								__nextHasNoMarginBottom
 								__next40pxDefaultSize
 								label={ label }
 								value={ allInputValue }
@@ -152,7 +147,6 @@ export default function BorderStyleControl( {
 									{ hasIndicator && <SideIndicatorControl side={ item.value } /> }
 									<ToggleGroupControl
 										hideLabelFromVision
-										__nextHasNoMarginBottom
 										__next40pxDefaultSize
 										label={ item.label }
 										value={ values[ item.value as ValuesKey ] || undefined }

--- a/src/controls/border-width-control.tsx
+++ b/src/controls/border-width-control.tsx
@@ -135,11 +135,7 @@ export default function BorderWidthControl( {
 	};
 
 	return (
-		<BaseControl
-			className={ clsx( 'ftb-border-width-control', className ) }
-			help={ help }
-			__nextHasNoMarginBottom
-		>
+		<BaseControl className={ clsx( 'ftb-border-width-control', className ) } help={ help }>
 			<VStack aria-labelledby={ headingId } role="group">
 				<Text id={ headingId } upperCase size="11" weight="500">
 					{ label }

--- a/src/controls/color-control.tsx
+++ b/src/controls/color-control.tsx
@@ -68,11 +68,7 @@ export default function ColorControl( {
 	const handleOnPickerClose = () => setIsPickerOpen( false );
 
 	return (
-		<BaseControl
-			className={ clsx( 'ftb-color-control', className ) }
-			help={ help }
-			__nextHasNoMarginBottom
-		>
+		<BaseControl className={ clsx( 'ftb-color-control', className ) } help={ help }>
 			<VStack aria-labelledby={ headingId } role="group">
 				<Text id={ headingId } upperCase size="11" weight="500">
 					{ label }

--- a/src/controls/padding-control.tsx
+++ b/src/controls/padding-control.tsx
@@ -106,11 +106,7 @@ export default function PaddingControl( {
 	};
 
 	return (
-		<BaseControl
-			className={ clsx( 'ftb-padding-control', className ) }
-			help={ help }
-			__nextHasNoMarginBottom
-		>
+		<BaseControl className={ clsx( 'ftb-padding-control', className ) } help={ help }>
 			<VStack aria-labelledby={ headingId } role="group">
 				<Text id={ headingId } upperCase size="11" weight="500">
 					{ label }

--- a/src/elements/table-placeholder.tsx
+++ b/src/elements/table-placeholder.tsx
@@ -176,13 +176,11 @@ export default function TablePlaceholder( { setAttributes }: Props ) {
 						label={ __( 'Header section', 'flexible-table-block' ) }
 						checked={ !! headerSection }
 						onChange={ onToggleHeaderSection }
-						__nextHasNoMarginBottom
 					/>
 					<ToggleControl
 						label={ __( 'Footer section', 'flexible-table-block' ) }
 						checked={ !! footerSection }
 						onChange={ onToggleFooterSection }
-						__nextHasNoMarginBottom
 					/>
 				</HStack>
 				<HStack wrap alignment="end" justify="start">
@@ -194,7 +192,6 @@ export default function TablePlaceholder( { setAttributes }: Props ) {
 						max={ MAX_PREVIEW_TABLE_COL }
 						value={ colCount || '' }
 						onChange={ onChangeColumnCount }
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 					/>
 					<TextControl
@@ -205,7 +202,6 @@ export default function TablePlaceholder( { setAttributes }: Props ) {
 						max={ MAX_PREVIEW_TABLE_ROW }
 						value={ rowCount || '' }
 						onChange={ onChangeRowCount }
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 					/>
 					<Button

--- a/src/settings/global-settings/setting-modal.tsx
+++ b/src/settings/global-settings/setting-modal.tsx
@@ -288,7 +288,6 @@ export default function SettingModal( {
 										className="ftb-global-setting-modal__styles-item"
 									>
 										<ToggleGroupControl
-											__nextHasNoMarginBottom
 											__next40pxDefaultSize
 											label={ __( 'Cell borders', 'flexible-table-block' ) }
 											value={ currentOptions.block_style?.table_border_collapse }
@@ -569,7 +568,6 @@ export default function SettingModal( {
 										className="ftb-global-setting-modal__styles-item"
 									>
 										<ToggleGroupControl
-											__nextHasNoMarginBottom
 											__next40pxDefaultSize
 											label={ __( 'Cell text alignment', 'flexible-table-block' ) }
 											value={ currentOptions.block_style?.cell_text_align }
@@ -607,7 +605,6 @@ export default function SettingModal( {
 										className="ftb-global-setting-modal__styles-item"
 									>
 										<ToggleGroupControl
-											__nextHasNoMarginBottom
 											__next40pxDefaultSize
 											label={ __( 'Cell vertical alignment', 'flexible-table-block' ) }
 											value={ currentOptions.block_style?.cell_vertical_align }
@@ -669,7 +666,6 @@ export default function SettingModal( {
 										} );
 									} }
 									__next40pxDefaultSize
-									__nextHasNoMarginBottom
 								/>
 							</VStack>
 						) }
@@ -688,7 +684,6 @@ export default function SettingModal( {
 											show_label_on_section: value,
 										} );
 									} }
-									__nextHasNoMarginBottom
 								/>
 								<ToggleControl
 									label={ __( 'Show control buttons', 'flexible-table-block' ) }
@@ -703,7 +698,6 @@ export default function SettingModal( {
 											show_control_button: value,
 										} );
 									} }
-									__nextHasNoMarginBottom
 								/>
 								{ ( currentOptions.show_label_on_section ||
 									currentOptions.show_control_button ) && (
@@ -723,7 +717,6 @@ export default function SettingModal( {
 												focus_control_button: value,
 											} );
 										} }
-										__nextHasNoMarginBottom
 									/>
 								) }
 								<ToggleControl
@@ -739,7 +732,6 @@ export default function SettingModal( {
 											show_dot_on_th: value,
 										} );
 									} }
-									__nextHasNoMarginBottom
 								/>
 								<ToggleControl
 									label={ __( 'Use the tab key to move cells', 'flexible-table-block' ) }
@@ -754,7 +746,6 @@ export default function SettingModal( {
 											tab_move: value,
 										} );
 									} }
-									__nextHasNoMarginBottom
 								/>
 								<ToggleControl
 									label={ __( 'Keep all contents when merging cells', 'flexible-table-block' ) }
@@ -769,7 +760,6 @@ export default function SettingModal( {
 											merge_content: value,
 										} );
 									} }
-									__nextHasNoMarginBottom
 								/>
 								{ canManageOptions && (
 									<ToggleControl
@@ -788,7 +778,6 @@ export default function SettingModal( {
 												show_global_setting: value,
 											} );
 										} }
-										__nextHasNoMarginBottom
 									/>
 								) }
 							</VStack>

--- a/src/settings/table-caption-settings.tsx
+++ b/src/settings/table-caption-settings.tsx
@@ -130,7 +130,6 @@ export default function TableCaptionSettings( {
 						type="number"
 						value={ captionStylesObj?.lineHeight || '' }
 						min={ 0 }
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 					/>
 				</FlexBlock>
@@ -142,7 +141,6 @@ export default function TableCaptionSettings( {
 				onChange={ onChangePadding }
 			/>
 			<ToggleGroupControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				className="ftb-table-caption-settings-position"
 				label={ __( 'Caption position', 'flexible-table-block' ) }
@@ -155,7 +153,6 @@ export default function TableCaptionSettings( {
 				) ) }
 			</ToggleGroupControl>
 			<ToggleGroupControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				className="ftb-table-caption-settings-text-alignment"
 				label={ __( 'Caption text alignment', 'flexible-table-block' ) }

--- a/src/settings/table-cell-settings.tsx
+++ b/src/settings/table-cell-settings.tsx
@@ -243,7 +243,6 @@ export default function TableCellSettings( { setAttributes, vTable, selectedCell
 						step={ 0.1 }
 						min={ 0 }
 						onChange={ onChangeLineHeight }
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 					/>
 				</FlexBlock>
@@ -260,7 +259,6 @@ export default function TableCellSettings( { setAttributes, vTable, selectedCell
 			/>
 			<ToggleGroupControl
 				className="ftb-table-cell-settings-percentage-width"
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				hideLabelFromVision
 				label={ __( 'Cell percentage width', 'flexible-table-block' ) }
@@ -344,7 +342,6 @@ export default function TableCellSettings( { setAttributes, vTable, selectedCell
 				<Flex style={ { marginBottom: '-16px' } } justify="start" align="start">
 					<ToggleGroupControl
 						hideLabelFromVision
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 						label={ __( 'Text alignment', 'flexible-table-block' ) }
 						value={ cellStylesObj?.textAlign }
@@ -362,7 +359,6 @@ export default function TableCellSettings( { setAttributes, vTable, selectedCell
 					</ToggleGroupControl>
 					<ToggleGroupControl
 						hideLabelFromVision
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 						label={ __( 'Vertical alignment', 'flexible-table-block' ) }
 						value={ cellStylesObj?.verticalAlign }
@@ -383,7 +379,6 @@ export default function TableCellSettings( { setAttributes, vTable, selectedCell
 			<hr />
 			<ToggleGroupControl
 				className="ftb-table-cell-settings-tag"
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				label={ __( 'Cell tag', 'flexible-table-block' ) }
 				value={ targetCell.tag }
@@ -401,7 +396,6 @@ export default function TableCellSettings( { setAttributes, vTable, selectedCell
 				value={ targetCell.className || '' }
 				onChange={ onChangeClass }
 				help={ __( 'Separate multiple classes with spaces.', 'flexible-table-block' ) }
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 			/>
 			{ selectedCellTags.length === 1 && (
@@ -417,7 +411,6 @@ export default function TableCellSettings( { setAttributes, vTable, selectedCell
 							autoComplete="off"
 							value={ targetCell.id || '' }
 							onChange={ onChangeId }
-							__nextHasNoMarginBottom
 							__next40pxDefaultSize
 						/>
 					) }
@@ -430,7 +423,6 @@ export default function TableCellSettings( { setAttributes, vTable, selectedCell
 						autoComplete="off"
 						value={ targetCell.headers || '' }
 						onChange={ onChangeHeaders }
-						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 					/>
 					{ selectedCellTags.includes( 'th' ) && (
@@ -446,7 +438,6 @@ export default function TableCellSettings( { setAttributes, vTable, selectedCell
 							} ) }
 							onChange={ ( value ) => onChangeScope( value as CellScopeValue ) }
 							size="__unstable-large"
-							__nextHasNoMarginBottom
 						/>
 					) }
 				</>

--- a/src/settings/table-settings.tsx
+++ b/src/settings/table-settings.tsx
@@ -254,14 +254,12 @@ export default function TableSettings( {
 				label={ __( 'Header section', 'flexible-table-block' ) }
 				checked={ !! ( head && head.length ) }
 				onChange={ onToggleHeaderSection }
-				__nextHasNoMarginBottom
 			/>
 			<ToggleControl
 				className="ftb-table-settings-footer"
 				label={ __( 'Footer section', 'flexible-table-block' ) }
 				checked={ !! ( foot && foot.length ) }
 				onChange={ onToggleFooterSection }
-				__nextHasNoMarginBottom
 			/>
 			<hr />
 			<ToggleControl
@@ -269,7 +267,6 @@ export default function TableSettings( {
 				label={ __( 'Fixed width table cells', 'flexible-table-block' ) }
 				checked={ !! hasFixedLayout }
 				onChange={ onChangeHasFixedLayout }
-				__nextHasNoMarginBottom
 			/>
 			<ToggleControl
 				className="ftb-table-settings-scroll-on-desktop"
@@ -284,7 +281,6 @@ export default function TableSettings( {
 					)
 				}
 				onChange={ onChangeIsScrollOnPc }
-				__nextHasNoMarginBottom
 			/>
 			<ToggleControl
 				className="ftb-table-settings-scroll-on-mobile"
@@ -299,7 +295,6 @@ export default function TableSettings( {
 					)
 				}
 				onChange={ onChangeIsScrollOnMobile }
-				__nextHasNoMarginBottom
 			/>
 			<ToggleControl
 				className="ftb-table-settings-stack-on-mobile"
@@ -314,7 +309,6 @@ export default function TableSettings( {
 					)
 				}
 				onChange={ onChangeIsStackedOnMobile }
-				__nextHasNoMarginBottom
 			/>
 			<SelectControl
 				className="ftb-table-settings-fixed-control"
@@ -333,7 +327,6 @@ export default function TableSettings( {
 				}
 				onChange={ onChangeSticky }
 				size="__unstable-large"
-				__nextHasNoMarginBottom
 			/>
 			<hr />
 			<UnitControl
@@ -348,7 +341,6 @@ export default function TableSettings( {
 				__unstableInputWidth="50%"
 			/>
 			<ToggleGroupControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				hideLabelFromVision
 				className="ftb-table-settings-percentage-width"
@@ -390,7 +382,6 @@ export default function TableSettings( {
 				__unstableInputWidth="50%"
 			/>
 			<ToggleGroupControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				hideLabelFromVision
 				className="ftb-table-settings-percentage-max-width"
@@ -431,7 +422,6 @@ export default function TableSettings( {
 				__unstableInputWidth="50%"
 			/>
 			<ToggleGroupControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				hideLabelFromVision
 				className="ftb-table-settings-percentage-min-width"
@@ -508,7 +498,6 @@ export default function TableSettings( {
 			/>
 			<hr />
 			<ToggleGroupControl
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				className="ftb-table-settings-cell-borders"
 				label={ __( 'Cell borders', 'flexible-table-block' ) }


### PR DESCRIPTION
The prop is now the default behavior in @wordpress/components, so passing it explicitly is redundant. Drop it from all BaseControl, ToggleGroupControl, ToggleControl, TextControl, SelectControl, and RangeControl usages.