### PR TITLE
Drop support for WordPress 6.9

### DIFF
--- a/.github/workflows/run-test-and-deploy.yml
+++ b/.github/workflows/run-test-and-deploy.yml
@@ -14,22 +14,22 @@ jobs:
           - php: '8.0'
             wp: WordPress
           - php: '8.0'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
           - php: '8.2'
             wp: WordPress
           - php: '8.2'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
           - php: '8.4'
             wp: WordPress
           - php: '8.4'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
           - php: '8.5'
             wp: WordPress
           - php: '8.5'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
     name: PHP ${{ matrix.php }} / ${{ matrix.wp }} Test
 

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -22,22 +22,22 @@ jobs:
           - php: '8.0'
             wp: WordPress
           - php: '8.0'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
           - php: '8.2'
             wp: WordPress
           - php: '8.2'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
           - php: '8.4'
             wp: WordPress
           - php: '8.4'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
           - php: '8.5'
             wp: WordPress
           - php: '8.5'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
     name: PHP ${{ matrix.php }} / ${{ matrix.wp }} Test
 

--- a/flexible-table-block.php
+++ b/flexible-table-block.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Flexible Table Block
  * Description: Easily create flexible configuration tables.
- * Requires at least: 6.9
+ * Requires at least: 7.0
  * Requires PHP: 8.0
  * Version: 3.8.0
  * Author: Aki Hamano

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wildworks, Toro_Unit
 Tags: gutenberg, block, table
 Donate link: https://www.paypal.me/thamanoJP
-Requires at least: 6.9
+Requires at least: 7.0
 Tested up to: 7.0
 Stable tag: 3.8.0
 Requires PHP: 8.0

--- a/test/e2e/specs/block-support.spec.ts
+++ b/test/e2e/specs/block-support.spec.ts
@@ -75,7 +75,6 @@ test.describe( 'Block Support', () => {
 	} );
 
 	test( 'dimensions settings should be applied', async ( { editor, page, fsbUtils } ) => {
-		const wpVersion = await fsbUtils.getWpVersion();
 		await fsbUtils.createFlexibleTableBlock();
 		// Open the sidebar.
 		await editor.openDocumentSettingsSidebar();
@@ -94,11 +93,7 @@ test.describe( 'Block Support', () => {
 		await page.getByRole( 'button', { name: 'Unlink' } ).click();
 		// Change margin values.
 		for ( let i = 0; i < 4; i++ ) {
-			if ( wpVersion === '6-9' ) {
-				await page.getByRole( 'button', { name: 'Set custom size' } ).nth( 1 ).click();
-			} else {
-				await page.getByRole( 'button', { name: 'Set custom value' } ).nth( 0 ).click();
-			}
+			await page.getByRole( 'button', { name: 'Set custom value' } ).nth( 0 ).click();
 		}
 		await page.getByRole( 'spinbutton', { name: 'Top margin' } ).fill( '10' );
 		await page.getByRole( 'spinbutton', { name: 'Right margin' } ).fill( '20' );

--- a/test/e2e/specs/table-cell.spec.ts
+++ b/test/e2e/specs/table-cell.spec.ts
@@ -85,8 +85,7 @@ test.describe( 'Flexible table cell', () => {
 			.getByRole( 'button', { name: 'Advanced' } )
 			.click();
 		await page.getByRole( 'checkbox', { name: 'Open in new tab' } ).click();
-		// The button text is "Apply" in WordPress 6.9 and later, and "Save" in earlier versions.
-		await page.getByRole( 'button', { name: /^(Save|Apply)$/, exact: true } ).click();
+		await page.getByRole( 'button', { name: 'Apply', exact: true } ).click();
 
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );

--- a/test/e2e/util.ts
+++ b/test/e2e/util.ts
@@ -72,14 +72,4 @@ export default class FlexibleTableBlockUtils {
 
 		await this.editor.canvas.getByRole( 'button', { name: 'Create Table' } ).click();
 	}
-
-	async getWpVersion() {
-		const body = await this.page.$( 'body' );
-		if ( ! body ) {
-			throw new Error( 'Could not find body element' );
-		}
-		const bodyClassNames = await ( await body.getProperty( 'className' ) ).jsonValue();
-		const matches = bodyClassNames.match( /branch-([0-9]*-*[0-9])/ );
-		return matches?.[ 1 ];
-	}
 }


### PR DESCRIPTION
Bump the minimum required WordPress version to 7.0 and remove the fallback code that branched on 6.9-specific behavior (the "Save"/"Apply" link button label and the "Set custom size" dimension control), along with the now-unused getWpVersion test helper. Update the CI matrix to test against the new 7.0 minimum instead of 6.9.