### PR TITLE
Announce row/column selection state to screen readers via aria-pressed

### DIFF
--- a/src/editor.scss
+++ b/src/editor.scss
@@ -281,11 +281,9 @@ $row-column-inserter-dot-size: 6px;
 		justify-content: center;
 		min-width: 0;
 		padding: 0;
-		color: colors.$gray-900;
-		background: colors.$gray-200;
 
-		svg {
-			margin-right: 0;
+		&:not(.is-pressed) {
+			background: colors.$gray-200;
 		}
 	}
 

--- a/src/elements/table.tsx
+++ b/src/elements/table.tsx
@@ -519,7 +519,6 @@ export default function Table( {
 															icon={ chevronRight }
 															iconSize={ 16 }
 															aria-pressed={ isCurrentRowSelected }
-															variant={ isCurrentRowSelected ? 'primary' : undefined }
 															onClick={ ( event: MouseEvent ) => {
 																onSelectRow( sectionName, rowIndex );
 																event.stopPropagation();
@@ -562,7 +561,6 @@ export default function Table( {
 															icon={ chevronDown }
 															iconSize={ 16 }
 															aria-pressed={ isCurrentColumnSelected }
-															variant={ isCurrentColumnSelected ? 'primary' : undefined }
 															onClick={ ( event: MouseEvent ) => {
 																onSelectColumn( vColIndex );
 																event.stopPropagation();

--- a/src/elements/table.tsx
+++ b/src/elements/table.tsx
@@ -446,6 +446,21 @@ export default function Table( {
 										targetCell.vColIndex === vColIndex
 								);
 
+								// Whether or not the row the current cell belongs to is selected.
+								// Coerced to a strict boolean so `aria-pressed` is always set
+								// (never `undefined`), keeping the button a toggle button so
+								// screen readers announce both pressed and unpressed states.
+								const isCurrentRowSelected = !! (
+									isRowSelected &&
+									selectedLine.sectionName === sectionName &&
+									selectedLine.rowIndex === rowIndex
+								);
+
+								// Whether or not the column the current cell belongs to is selected.
+								const isCurrentColumnSelected = !! (
+									isColumnSelected && selectedLine.vColIndex === vColIndex
+								);
+
 								const cellStylesObj = convertToObject( styles );
 
 								return (
@@ -503,33 +518,26 @@ export default function Table( {
 															tabIndex={ options.focus_control_button ? 0 : -1 }
 															icon={ chevronRight }
 															iconSize={ 16 }
-															variant={
-																isRowSelected &&
-																selectedLine.sectionName === sectionName &&
-																selectedLine.rowIndex === rowIndex
-																	? 'primary'
-																	: undefined
-															}
+															aria-pressed={ isCurrentRowSelected }
+															variant={ isCurrentRowSelected ? 'primary' : undefined }
 															onClick={ ( event: MouseEvent ) => {
 																onSelectRow( sectionName, rowIndex );
 																event.stopPropagation();
 															} }
 														/>
-														{ isRowSelected &&
-															selectedLine.sectionName === sectionName &&
-															selectedLine.rowIndex === rowIndex && (
-																<Button
-																	className="ftb-row-remover"
-																	label={ __( 'Delete row', 'flexible-table-block' ) }
-																	tabIndex={ options.focus_control_button ? 0 : -1 }
-																	size="compact"
-																	icon={ trash }
-																	onClick={ ( event: MouseEvent ) => {
-																		onDeleteRow( sectionName, rowIndex );
-																		event.stopPropagation();
-																	} }
-																/>
-															) }
+														{ isCurrentRowSelected && (
+															<Button
+																className="ftb-row-remover"
+																label={ __( 'Delete row', 'flexible-table-block' ) }
+																tabIndex={ options.focus_control_button ? 0 : -1 }
+																size="compact"
+																icon={ trash }
+																onClick={ ( event: MouseEvent ) => {
+																	onDeleteRow( sectionName, rowIndex );
+																	event.stopPropagation();
+																} }
+															/>
+														) }
 													</>
 												) }
 												{ sectionIndex === 0 && rowIndex === 0 && vColIndex === 0 && (
@@ -553,17 +561,14 @@ export default function Table( {
 															tabIndex={ options.focus_control_button ? 0 : -1 }
 															icon={ chevronDown }
 															iconSize={ 16 }
-															variant={
-																isColumnSelected && selectedLine.vColIndex === vColIndex
-																	? 'primary'
-																	: undefined
-															}
+															aria-pressed={ isCurrentColumnSelected }
+															variant={ isCurrentColumnSelected ? 'primary' : undefined }
 															onClick={ ( event: MouseEvent ) => {
 																onSelectColumn( vColIndex );
 																event.stopPropagation();
 															} }
 														/>
-														{ isColumnSelected && selectedLine.vColIndex === vColIndex && (
+														{ isCurrentColumnSelected && (
 															<Button
 																className="ftb-column-remover"
 																label={ __( 'Delete column', 'flexible-table-block' ) }

--- a/src/elements/table.tsx
+++ b/src/elements/table.tsx
@@ -447,9 +447,6 @@ export default function Table( {
 								);
 
 								// Whether or not the row the current cell belongs to is selected.
-								// Coerced to a strict boolean so `aria-pressed` is always set
-								// (never `undefined`), keeping the button a toggle button so
-								// screen readers announce both pressed and unpressed states.
 								const isCurrentRowSelected = !! (
 									isRowSelected &&
 									selectedLine.sectionName === sectionName &&

--- a/test/e2e/specs/table.spec.ts
+++ b/test/e2e/specs/table.spec.ts
@@ -128,7 +128,10 @@ test.describe( 'Flexible table', () => {
 			await page.keyboard.up( 'Shift' );
 			await editor.clickBlockToolbarButton( 'Edit table' );
 			await page.getByRole( 'menuitem', { name: 'Merge cells' } ).click();
-			await editor.canvas.getByRole( 'button', { name: 'Select row' } ).nth( 2 ).click();
+			const selectRowButton = editor.canvas.getByRole( 'button', { name: 'Select row' } ).nth( 2 );
+			await expect( selectRowButton ).toHaveAttribute( 'aria-pressed', 'false' );
+			await selectRowButton.click();
+			await expect( selectRowButton ).toHaveAttribute( 'aria-pressed', 'true' );
 			await editor.canvas.getByRole( 'button', { name: 'Delete row' } ).click();
 			expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 		} );
@@ -145,7 +148,12 @@ test.describe( 'Flexible table', () => {
 			await page.keyboard.up( 'Shift' );
 			await editor.clickBlockToolbarButton( 'Edit table' );
 			await page.getByRole( 'menuitem', { name: 'Merge cells' } ).click();
-			await editor.canvas.getByRole( 'button', { name: 'Select column' } ).nth( 2 ).click();
+			const selectColumnButton = editor.canvas
+				.getByRole( 'button', { name: 'Select column' } )
+				.nth( 2 );
+			await expect( selectColumnButton ).toHaveAttribute( 'aria-pressed', 'false' );
+			await selectColumnButton.click();
+			await expect( selectColumnButton ).toHaveAttribute( 'aria-pressed', 'true' );
 			await editor.canvas.getByRole( 'button', { name: 'Delete column' } ).click();
 			expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 		} );


### PR DESCRIPTION
The row and column selector buttons conveyed their selected state only visually (the primary button variant), so screen readers announced nothing when a row or column was selected or deselected.

These buttons are now proper toggle buttons via `aria-pressed`. The selected-state condition is extracted into `isCurrentRowSelected` / `isCurrentColumnSelected` and coerced to a strict boolean, so `aria-pressed` is always rendered as `true`/`false` instead of dropping to `undefined` when unselected — otherwise the element stops being a toggle button and the unpressed transition is never announced.

The redundant `primary` variant is removed since the Button already applies its `is-pressed` styling when pressed; the selector's gray background is scoped to the unpressed state so the pressed state shows the standard `is-pressed` appearance.

Existing E2E tests for deleting rows/columns now assert that `aria-pressed` flips from `false` to `true` on click.
